### PR TITLE
chore(issue-37): add when-to-skip and explicit Inputs/Outputs to remaining file-library skills

### DIFF
--- a/plugins/file-library/skills/implement-go-binary-file-library/SKILL.md
+++ b/plugins/file-library/skills/implement-go-binary-file-library/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement-go-binary-file-library
-description: Implement features for Go binary file library packages that follow a types/decoder/encoder pipeline. Use whenever the user wants to add struct types, decoder methods, encoder methods, bit-field handling, or checksum/integrity logic to a Go package built around `types.go`, `decoder.go`, and `encoder.go` — including phrases like "implement the X header", "add support for Y in the gzip package", "decode the Z field per SPEC.md", or "wire up the FLG bit field", even if the user doesn't say "binary".
+description: Implement features for Go binary file library packages that follow a types/decoder/encoder pipeline. Use whenever the user wants to add struct types, decoder methods, encoder methods, bit-field handling, or checksum/integrity logic to a Go package built around `types.go`, `decoder.go`, and `encoder.go` — including phrases like "implement the X header", "add support for Y in the gzip package", "decode the Z field per SPEC.md", or "wire up the FLG bit field", even if the user doesn't say "binary". Skip when the user wants to scaffold a brand-new package (use `new-go-binary-file-library` instead) or when the target package uses the text `tokenizer.go`/`parser.go`/`printer.go` layout (use `implement-go-text-file-library` instead).
 ---
 
 You are an orchestrator that adds features to an existing Go binary file library package. You prepare context, then delegate each pipeline phase (types → decoder → encoder) to a focused subagent. You never read the full `SPEC.md` into your own context — large specs would crowd out orchestration. Instead, grep `SPEC.md` for section line ranges and hand each subagent a `(path, offset, limit)` slice it can read directly.
@@ -8,14 +8,28 @@ You are an orchestrator that adds features to an existing Go binary file library
 Read `references/architecture.md` for the types/decoder/encoder patterns each subagent must follow (especially the `FieldError → OffsetError → leaf` chain, which all error sites funnel through).
 Read `references/testing.md` for binary-specific test conventions before launching any subagent.
 
+## Inputs
+
+- **Package path** (required) — the Go package directory the user wants changed (e.g. "implement the FLG bit field in `pkg/gzip`"). Source: user prompt. Validate by listing the directory; if `types.go`, `decoder.go`, `encoder.go`, or any of their `_test.go` siblings are missing, stop and direct the user to `new-go-binary-file-library`.
+- **`<package>/SPEC.md`** (optional) — when present, sliced by line range per phase; when absent, the user's request plus existing source files are the only context.
+- **`<package>/structures/*.md`, `<package>/encoding-tables/*.md`** (optional) — pre-chunked spec files produced by `extract-binary-spec`. Passed to subagents verbatim, no slicing.
+
+## Outputs
+
+- **Edits** to `<package>/types.go`, `<package>/types_test.go`, `<package>/decoder.go`, `<package>/decoder_test.go`, `<package>/encoder.go`, `<package>/encoder_test.go` — amended via `Edit`, never recreated wholesale, so prior implementer work is preserved.
+- **Stub-test replacement** — the decoder phase deletes/replaces any scaffold-only `TestDecodeStubReturnsErrUnimplemented`-style test; the encoder phase does the same for the `Encode` counterpart. These tests pin the unimplemented chain and start failing the moment the real public API is wired up, so removing them (rather than short-circuiting `Decode`/`Encode` to keep returning `errUnimplemented`) is the only valid resolution.
+- **Scratch files** `<package>/_context_types.md` (after Phase 1) and `<package>/_context_decoder.md` (after Phase 2) — overwritten each run, deleted in Cleanup. If a previous run was interrupted and left either file behind, delete them before launching Phase 1 so a stale partial summary cannot leak into the new run.
+- **Side effect**: runs `(cd <package> && go test -race ./...)` between phases to verify each phase before launching the next. The `cd` is required — this repo has no root `go.mod`, so each target package's tests must be run from inside that package.
+
 ## Before you start
 
 1. Read the package's `CLAUDE.md` (if present) and the repo-root `CLAUDE.md` for project conventions and license-header style.
 2. List the package: confirm `types.go`, `decoder.go`, `encoder.go`, and their `_test.go` siblings exist. If they don't, the user wants the `new-go-binary-file-library` scaffold first — say so and stop.
 3. Check for `<package>/SPEC.md`. If absent, the user's request and existing source files are the only context — pass them directly to each subagent and skip the partitioning step.
 4. Identify scope: which struct types, decoder methods, and encoder methods will change.
-5. **Note any scaffold-only stub tests** (e.g. `TestDecodeStubReturnsErrUnimplemented`, `TestEncodeStubReturnsErrUnimplemented`). These pin the unimplemented chain and will start failing the moment you wire up the real public API. The decoder phase deletes/replaces the `Decode` stub test; the encoder phase deletes/replaces the `Encode` stub test. Don't leave them green by short-circuiting `Decode`/`Encode` to keep returning `errUnimplemented`.
+5. **Note any scaffold-only stub tests** (e.g. `TestDecodeStubReturnsErrUnimplemented`, `TestEncodeStubReturnsErrUnimplemented`). See `## Outputs` for how each phase replaces them.
 6. **Check the user prompt against the spec.** If the user's request contradicts something in `SPEC.md` (e.g. the spec says reject a flag that the user wants supported), the user's prompt is the active intent — flag the conflict so they can confirm, then implement what the user asked for.
+7. **Re-run safety.** This skill is safe to re-run on the same package — see `## Outputs` for what is edited vs. overwritten vs. deleted.
 
 ## Partition SPEC.md by line range (do not read the whole file)
 

--- a/plugins/file-library/skills/new-go-binary-file-library/SKILL.md
+++ b/plugins/file-library/skills/new-go-binary-file-library/SKILL.md
@@ -1,11 +1,23 @@
 ---
 name: new-go-binary-file-library
-description: Scaffold a new Go binary file library package with types, decoder, encoder, and tests
+description: Scaffold a new Go binary file library package with types, decoder, encoder, and tests. Skip when the user wants to add features to an existing binary package (use `implement-go-binary-file-library` instead) or when the target format is text, e.g. `tokenizer.go`/`parser.go`/`printer.go` (use `new-go-text-file-library` instead).
 disable-model-invocation: true
 argument-hint: "[package-name]"
 ---
 
 Scaffold a new Go binary file library package at `./$ARGUMENTS[0]/` following the **types / decoder / encoder** pipeline. The package name is `$ARGUMENTS[0]`. Read `references/architecture.md` for the patterns each generated file must implement and why — especially the section on the decode/encode error chain, which the scaffold pre-wires.
+
+## Inputs
+
+- **`$ARGUMENTS[0]`** (required) — the package name, supplied as the slash-command argument (e.g. `/new-go-binary-file-library gzip`). Used both as the directory name (`./$ARGUMENTS[0]/`) and the Go `package` identifier, so it must be a valid Go identifier (lowercase, no hyphens, no leading digit). Validate by listing `./$ARGUMENTS[0]/`; if the directory already exists with any of the files in `## Outputs` present, stop and direct the user to `implement-go-binary-file-library` so prior work is not clobbered.
+
+## Outputs
+
+- **Generated files** in `./$ARGUMENTS[0]/`, written via `Write`: `doc.go`, `types.go`, `types_test.go`, `decoder.go`, `decoder_test.go`, `encoder.go`, `encoder_test.go`, `CLAUDE.md`. Each is a Go source file (or, for `CLAUDE.md`, package-level guidance markdown) — see `## What to Generate` for per-file content. `Write` will overwrite an existing file at the same path, which is why the input-validation step above refuses to run against a non-empty target directory.
+- **Side effects** (run from the repo root after files are written):
+  - `go mod tidy` — refreshes the package's module dependencies; assumes a `go.mod` is already in scope (root or package-level).
+  - `go build ./$ARGUMENTS[0]/...` — verifies compilation.
+  - `go test ./$ARGUMENTS[0]/...` — placeholder tests must pass against the unimplemented stubs (the `FieldError → OffsetError → errUnimplemented` chain is real even though the bytes aren't) before reporting success.
 
 ## Before Scaffolding
 

--- a/plugins/file-library/skills/new-go-binary-file-library/SKILL.md
+++ b/plugins/file-library/skills/new-go-binary-file-library/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-go-binary-file-library
-description: Scaffold a new Go binary file library package with types, decoder, encoder, and tests. Skip when the user wants to add features to an existing binary package (use `implement-go-binary-file-library` instead) or when the target format is text, e.g. `tokenizer.go`/`parser.go`/`printer.go` (use `new-go-text-file-library` instead).
+description: Scaffold a new Go binary file library package with types, decoder, encoder, and tests. Use when the user asks to "scaffold a new binary decoder/encoder package" or "start a new binary format library". Skip when the user wants to add features to an existing binary package (use `implement-go-binary-file-library` instead) or when the target format is text, e.g. `tokenizer.go`/`parser.go`/`printer.go` (use `new-go-text-file-library` instead).
 disable-model-invocation: true
 argument-hint: "[package-name]"
 ---
@@ -9,15 +9,15 @@ Scaffold a new Go binary file library package at `./$ARGUMENTS[0]/` following th
 
 ## Inputs
 
-- **`$ARGUMENTS[0]`** (required) — the package name, supplied as the slash-command argument (e.g. `/new-go-binary-file-library gzip`). Used both as the directory name (`./$ARGUMENTS[0]/`) and the Go `package` identifier, so it must be a valid Go identifier (lowercase, no hyphens, no leading digit). Validate by listing `./$ARGUMENTS[0]/`; if the directory already exists with any of the files in `## Outputs` present, stop and direct the user to `implement-go-binary-file-library` so prior work is not clobbered.
+- **`$ARGUMENTS[0]`** (required) — the package name, supplied as the slash-command argument (e.g. `/new-go-binary-file-library gzip`). Used both as the directory name (`./$ARGUMENTS[0]/`) and the Go `package` identifier. Validate by listing `./$ARGUMENTS[0]/`; if the directory already exists with any of the files in `## Outputs` present, stop and direct the user to `implement-go-binary-file-library` so prior work is not clobbered. An invalid Go identifier (hyphens, leading digit, etc.) will surface as a `go build` failure in `## After Scaffolding`.
 
 ## Outputs
 
-- **Generated files** in `./$ARGUMENTS[0]/`, written via `Write`: `doc.go`, `types.go`, `types_test.go`, `decoder.go`, `decoder_test.go`, `encoder.go`, `encoder_test.go`, `CLAUDE.md`. Each is a Go source file (or, for `CLAUDE.md`, package-level guidance markdown) — see `## What to Generate` for per-file content. `Write` will overwrite an existing file at the same path, which is why the input-validation step above refuses to run against a non-empty target directory.
-- **Side effects** (run from the repo root after files are written):
-  - `go mod tidy` — refreshes the package's module dependencies; assumes a `go.mod` is already in scope (root or package-level).
-  - `go build ./$ARGUMENTS[0]/...` — verifies compilation.
-  - `go test ./$ARGUMENTS[0]/...` — placeholder tests must pass against the unimplemented stubs (the `FieldError → OffsetError → errUnimplemented` chain is real even though the bytes aren't) before reporting success.
+- **Generated files** in `./$ARGUMENTS[0]/`, written via `Write`: `doc.go`, `types.go`, `types_test.go`, `decoder.go`, `decoder_test.go`, `encoder.go`, `encoder_test.go`, `CLAUDE.md`. Each is a Go source file (or, for `CLAUDE.md`, package-level guidance markdown) — see `## What to Generate` for per-file content. `Write` will overwrite an existing file at the same path, which is why the input-validation step above stops if any of those output paths already exist in the target directory.
+- **Side effects** (run from `./$ARGUMENTS[0]/` after files are written; this repo has no root `go.mod`, so each new package's tests must be run from inside the package):
+  - `(cd ./$ARGUMENTS[0] && go mod tidy)` — refreshes module dependencies.
+  - `(cd ./$ARGUMENTS[0] && go build ./...)` — verifies compilation.
+  - `(cd ./$ARGUMENTS[0] && go test -race ./...)` — placeholder tests must pass against the unimplemented stubs (the `FieldError → OffsetError → errUnimplemented` chain is real even though the bytes aren't) before reporting success.
 
 ## Before Scaffolding
 
@@ -91,7 +91,7 @@ Base the structure on any existing package-level `CLAUDE.md` in the repo, or wri
 
 ## After Scaffolding
 
-1. `go mod tidy`.
-2. `go build ./$ARGUMENTS[0]/...` to verify compilation.
-3. `go test ./$ARGUMENTS[0]/...` — placeholder tests should pass against the unimplemented stubs (the chain is real even though the bytes aren't).
+1. `(cd ./$ARGUMENTS[0] && go mod tidy)`.
+2. `(cd ./$ARGUMENTS[0] && go build ./...)` to verify compilation.
+3. `(cd ./$ARGUMENTS[0] && go test -race ./...)` — placeholder tests should pass against the unimplemented stubs (the chain is real even though the bytes aren't).
 4. Report what was created, the byte order chosen, and what the user should implement next (typically: define the real types from `SPEC.md`, then run the `implement-go-binary-file-library` agent).

--- a/plugins/file-library/skills/new-go-text-file-library/SKILL.md
+++ b/plugins/file-library/skills/new-go-text-file-library/SKILL.md
@@ -1,11 +1,23 @@
 ---
 name: new-go-text-file-library
-description: Scaffold a new Go text file library package with tokenizer, parser, printer, and tests
+description: Scaffold a new Go text file library package with tokenizer, parser, printer, and tests. Skip when the user wants to add features to an existing text package (use `implement-go-text-file-library` instead) or when the target format is binary, e.g. `types.go`/`decoder.go`/`encoder.go` (use `new-go-binary-file-library` instead).
 disable-model-invocation: true
 argument-hint: "[package-name]"
 ---
 
 Scaffold a new Go text file library package at `./$ARGUMENTS[0]/` following the **tokenizer / parser / printer** pipeline. The package name is `$ARGUMENTS[0]`. Read `references/architecture.md` for the patterns each generated file must implement and why — especially the action-loop state machine that the tokenizer, parser, and printer all share.
+
+## Inputs
+
+- **`$ARGUMENTS[0]`** (required) — the package name, supplied as the slash-command argument (e.g. `/new-go-text-file-library kvr`). Used both as the directory name (`./$ARGUMENTS[0]/`) and the Go `package` identifier, so it must be a valid Go identifier (lowercase, no hyphens, no leading digit). Validate by listing `./$ARGUMENTS[0]/`; if the directory already exists with any of the files in `## Outputs` present, stop and direct the user to `implement-go-text-file-library` so prior work is not clobbered.
+
+## Outputs
+
+- **Generated files** in `./$ARGUMENTS[0]/`, written via `Write`: `doc.go`, `tokenizer.go`, `tokenizer_test.go`, `parser.go`, `parser_test.go`, `printer.go`, `printer_test.go`, `CLAUDE.md`. Each is a Go source file (or, for `CLAUDE.md`, package-level guidance markdown) — see `## What to Generate` for per-file content. `Write` will overwrite an existing file at the same path, which is why the input-validation step above refuses to run against a non-empty target directory.
+- **Side effects** (run from the repo root after files are written):
+  - `go mod tidy` — refreshes the package's module dependencies; assumes a `go.mod` is already in scope (root or package-level).
+  - `go build ./$ARGUMENTS[0]/...` — verifies compilation.
+  - `go test -race ./$ARGUMENTS[0]/...` — placeholder tests must pass against the empty-input stubs before reporting success.
 
 ## Before Scaffolding
 

--- a/plugins/file-library/skills/new-go-text-file-library/SKILL.md
+++ b/plugins/file-library/skills/new-go-text-file-library/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-go-text-file-library
-description: Scaffold a new Go text file library package with tokenizer, parser, printer, and tests. Skip when the user wants to add features to an existing text package (use `implement-go-text-file-library` instead) or when the target format is binary, e.g. `types.go`/`decoder.go`/`encoder.go` (use `new-go-binary-file-library` instead).
+description: Scaffold a new Go text file library package with tokenizer, parser, printer, and tests. Use when the user asks to "start a new <format> library" or "scaffold a new <format> parser". Skip when the user wants to add features to an existing text package (use `implement-go-text-file-library` instead) or when the target format is binary, e.g. `types.go`/`decoder.go`/`encoder.go` (use `new-go-binary-file-library` instead).
 disable-model-invocation: true
 argument-hint: "[package-name]"
 ---
@@ -9,15 +9,15 @@ Scaffold a new Go text file library package at `./$ARGUMENTS[0]/` following the 
 
 ## Inputs
 
-- **`$ARGUMENTS[0]`** (required) — the package name, supplied as the slash-command argument (e.g. `/new-go-text-file-library kvr`). Used both as the directory name (`./$ARGUMENTS[0]/`) and the Go `package` identifier, so it must be a valid Go identifier (lowercase, no hyphens, no leading digit). Validate by listing `./$ARGUMENTS[0]/`; if the directory already exists with any of the files in `## Outputs` present, stop and direct the user to `implement-go-text-file-library` so prior work is not clobbered.
+- **`$ARGUMENTS[0]`** (required) — the package name, supplied as the slash-command argument (e.g. `/new-go-text-file-library kvr`). Used both as the directory name (`./$ARGUMENTS[0]/`) and the Go `package` identifier. Validate by listing `./$ARGUMENTS[0]/`; if the directory already exists with any of the files in `## Outputs` present, stop and direct the user to `implement-go-text-file-library` so prior work is not clobbered. An invalid Go identifier (hyphens, leading digit, etc.) will surface as a `go build` failure in `## After Scaffolding`.
 
 ## Outputs
 
-- **Generated files** in `./$ARGUMENTS[0]/`, written via `Write`: `doc.go`, `tokenizer.go`, `tokenizer_test.go`, `parser.go`, `parser_test.go`, `printer.go`, `printer_test.go`, `CLAUDE.md`. Each is a Go source file (or, for `CLAUDE.md`, package-level guidance markdown) — see `## What to Generate` for per-file content. `Write` will overwrite an existing file at the same path, which is why the input-validation step above refuses to run against a non-empty target directory.
-- **Side effects** (run from the repo root after files are written):
-  - `go mod tidy` — refreshes the package's module dependencies; assumes a `go.mod` is already in scope (root or package-level).
-  - `go build ./$ARGUMENTS[0]/...` — verifies compilation.
-  - `go test -race ./$ARGUMENTS[0]/...` — placeholder tests must pass against the empty-input stubs before reporting success.
+- **Generated files** in `./$ARGUMENTS[0]/`, written via `Write`: `doc.go`, `tokenizer.go`, `tokenizer_test.go`, `parser.go`, `parser_test.go`, `printer.go`, `printer_test.go`, `CLAUDE.md`. Each is a Go source file (or, for `CLAUDE.md`, package-level guidance markdown) — see `## What to Generate` for per-file content. `Write` will overwrite an existing file at the same path, which is why the input-validation step above stops if any of those output paths already exist in the target directory.
+- **Side effects** (run from `./$ARGUMENTS[0]/` after files are written; this repo has no root `go.mod`, so each new package's tests must be run from inside the package):
+  - `(cd ./$ARGUMENTS[0] && go mod tidy)` — refreshes module dependencies.
+  - `(cd ./$ARGUMENTS[0] && go build ./...)` — verifies compilation.
+  - `(cd ./$ARGUMENTS[0] && go test -race ./...)` — placeholder tests must pass against the empty-input stubs before reporting success.
 
 ## Before Scaffolding
 
@@ -94,7 +94,7 @@ If a package-level `CLAUDE.md` already exists elsewhere in the repo, mirror its 
 
 ## After Scaffolding
 
-1. `go mod tidy`.
-2. `go build ./$ARGUMENTS[0]/...` to verify compilation.
-3. `go test -race ./$ARGUMENTS[0]/...` — placeholder tests should pass against the empty-input stubs.
+1. `(cd ./$ARGUMENTS[0] && go mod tidy)`.
+2. `(cd ./$ARGUMENTS[0] && go build ./...)` to verify compilation.
+3. `(cd ./$ARGUMENTS[0] && go test -race ./...)` — placeholder tests should pass against the empty-input stubs.
 4. Report what was created and what the user should implement next (typically: extract a `SPEC.md` with `extract-text-spec`, then run the `implement-go-text-file-library` agent).


### PR DESCRIPTION
## Summary

- Mirror the strict-definitions fixes from PR #36 (dfef815) onto the three sister skills in `plugins/file-library/skills/`: `implement-go-binary-file-library`, `new-go-text-file-library`, `new-go-binary-file-library`.
- Per audit-skill `checks/strict-definitions.md` §1, §3, §4: append "skip when ..." clauses to each description (the two scaffolders redirect to each other and to their matching `implement-go-*` skill; `implement-go-binary` redirects scaffold requests to `new-go-binary` and text-format requests to `implement-go-text`), add `## Inputs` declaring source / required / validation, and add `## Outputs` declaring path / format / overwrite-or-delete behavior plus side effects.
- For `implement-go-binary`, anchor the new Outputs side-effect line to `(cd <package> && go test -race ./...)` (the repo has no root `go.mod`, matching the latest text-skill shape); trim step 5 stub-test prose to a one-line cross-reference to `## Outputs`; add step 7 `Re-run safety`. The body's inline `go test` references are intentionally left untouched — the cd-form anchoring inside the workflow body was a separate concern handled in PR #36 commit 4b26cc1 and is out of scope for issue #37.

Closes #37.

## Test plan

- [x] All three SKILL.md descriptions name 1-2 concrete "skip when ..." cases pointing at the correct sister skill.
- [x] All three SKILL.md files declare `## Inputs` above the existing pre-flight section, with source / required-ness / validation for each input.
- [x] All three SKILL.md files declare `## Outputs` with paths, overwrite/delete behavior, and `go test` side effects.
- [x] `implement-go-binary-file-library/SKILL.md` Outputs side-effect line uses `(cd <package> && go test -race ./...)` and explains why (no root `go.mod`).
- [ ] Reviewer should sanity-check the Inputs validation rules (especially "refuse against non-empty target directory" for the two scaffolders) against actual scaffolder behavior — these were inferred from `Write` semantics rather than tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)