### PR TITLE
chore(issue-39): declare source + validation for optional inputs in implementer skills

### DIFF
--- a/plugins/file-library/skills/implement-go-binary-file-library/SKILL.md
+++ b/plugins/file-library/skills/implement-go-binary-file-library/SKILL.md
@@ -11,8 +11,8 @@ Read `references/testing.md` for binary-specific test conventions before launchi
 ## Inputs
 
 - **Package path** (required) — the Go package directory the user wants changed (e.g. "implement the FLG bit field in `pkg/gzip`"). Source: user prompt. Validate by listing the directory; if `types.go`, `decoder.go`, `encoder.go`, or any of their `_test.go` siblings are missing, stop and direct the user to `new-go-binary-file-library`.
-- **`<package>/SPEC.md`** (optional) — when present, sliced by line range per phase; when absent, the user's request plus existing source files are the only context.
-- **`<package>/structures/*.md`, `<package>/encoding-tables/*.md`** (optional) — pre-chunked spec files produced by `extract-binary-spec`. Passed to subagents verbatim, no slicing.
+- **`<package>/SPEC.md`** (optional) — Source: filesystem. When present, sliced by line range per phase. When the path is missing, continue without it — the user's request plus existing source files are the only context. When the path exists but is unreadable (e.g. permissions error), stop and ask the user to fix the path or permissions before continuing.
+- **`<package>/structures/*.md`, `<package>/encoding-tables/*.md`** (optional) — Source: filesystem. Pre-chunked spec files produced by `extract-binary-spec`; when present, passed to subagents verbatim, no slicing. When no matching files exist, continue without them. When a matched path exists but is unreadable, stop and ask the user to fix the path or permissions before continuing.
 
 ## Outputs
 

--- a/plugins/file-library/skills/implement-go-binary-file-library/SKILL.md
+++ b/plugins/file-library/skills/implement-go-binary-file-library/SKILL.md
@@ -12,7 +12,7 @@ Read `references/testing.md` for binary-specific test conventions before launchi
 
 - **Package path** (required) — the Go package directory the user wants changed (e.g. "implement the FLG bit field in `pkg/gzip`"). Source: user prompt. Validate by listing the directory; if `types.go`, `decoder.go`, `encoder.go`, or any of their `_test.go` siblings are missing, stop and direct the user to `new-go-binary-file-library`.
 - **`<package>/SPEC.md`** (optional) — Source: filesystem. When present, sliced by line range per phase. When the path is missing, continue without it — the user's request plus existing source files are the only context. When the path exists but is unreadable (e.g. permissions error), stop and ask the user to fix the path or permissions before continuing.
-- **`<package>/structures/*.md`, `<package>/encoding-tables/*.md`** (optional) — Source: filesystem. Pre-chunked spec files produced by `extract-binary-spec`; when present, passed to subagents verbatim, no slicing. When no matching files exist, continue without them. When a matched path exists but is unreadable, stop and ask the user to fix the path or permissions before continuing.
+- **`<package>/structures/*.md`, `<package>/encoding-tables/*.md`** (optional) — Source: filesystem. Pre-chunked spec files produced by `extract-binary-spec`; when present, passed to subagents verbatim, no slicing. When no matching files exist, continue without them. If the `structures/` or `encoding-tables/` directory exists but cannot be read/listed, stop and ask the user to fix the path or permissions before continuing. When a matched path exists but is unreadable, stop and ask the user to fix the path or permissions before continuing.
 
 ## Outputs
 

--- a/plugins/file-library/skills/implement-go-text-file-library/SKILL.md
+++ b/plugins/file-library/skills/implement-go-text-file-library/SKILL.md
@@ -11,8 +11,8 @@ Read `references/testing.md` for text-specific test conventions before launching
 ## Inputs
 
 - **Package path** (required) — the Go package directory the user wants changed (e.g. "implement comments in `pkg/kvr`"). Source: user prompt. Validate by listing the directory; if `tokenizer.go`, `parser.go`, `printer.go`, or any of their `_test.go` siblings are missing, stop and direct the user to `new-go-text-file-library`.
-- **`<package>/SPEC.md`** (optional) — when present, sliced by line range per phase; when absent, the user's request plus existing source files are the only context.
-- **`<package>/tokens/*.md`, `<package>/grammar/*.md`** (optional) — pre-chunked spec files produced by `extract-text-spec`. Passed to subagents verbatim, no slicing.
+- **`<package>/SPEC.md`** (optional) — Source: filesystem. When present, sliced by line range per phase. When the path is missing, continue without it — the user's request plus existing source files are the only context. When the path exists but is unreadable (e.g. permissions error), stop and ask the user to fix the path or permissions before continuing.
+- **`<package>/tokens/*.md`, `<package>/grammar/*.md`** (optional) — Source: filesystem. Pre-chunked spec files produced by `extract-text-spec`; when present, passed to subagents verbatim, no slicing. When no matching files exist, continue without them. When a matched path exists but is unreadable, stop and ask the user to fix the path or permissions before continuing.
 
 ## Outputs
 

--- a/plugins/file-library/skills/implement-go-text-file-library/SKILL.md
+++ b/plugins/file-library/skills/implement-go-text-file-library/SKILL.md
@@ -12,7 +12,7 @@ Read `references/testing.md` for text-specific test conventions before launching
 
 - **Package path** (required) — the Go package directory the user wants changed (e.g. "implement comments in `pkg/kvr`"). Source: user prompt. Validate by listing the directory; if `tokenizer.go`, `parser.go`, `printer.go`, or any of their `_test.go` siblings are missing, stop and direct the user to `new-go-text-file-library`.
 - **`<package>/SPEC.md`** (optional) — Source: filesystem. When present, sliced by line range per phase. When the path is missing, continue without it — the user's request plus existing source files are the only context. When the path exists but is unreadable (e.g. permissions error), stop and ask the user to fix the path or permissions before continuing.
-- **`<package>/tokens/*.md`, `<package>/grammar/*.md`** (optional) — Source: filesystem. Pre-chunked spec files produced by `extract-text-spec`; when present, passed to subagents verbatim, no slicing. When no matching files exist, continue without them. When a matched path exists but is unreadable, stop and ask the user to fix the path or permissions before continuing.
+- **`<package>/tokens/*.md`, `<package>/grammar/*.md`** (optional) — Source: filesystem. Pre-chunked spec files produced by `extract-text-spec`; when present, passed to subagents verbatim, no slicing. When no matching files exist, continue without them. If the `tokens/` or `grammar/` directory exists but cannot be read/listed, stop and ask the user to fix the path or permissions before continuing. When a matched path exists but is unreadable, stop and ask the user to fix the path or permissions before continuing.
 
 ## Outputs
 


### PR DESCRIPTION
## Summary
- Expands the optional-input bullets in `implement-go-text-file-library` and `implement-go-binary-file-library` SKILL.md to declare `Source: filesystem`, missing-path behavior (continue without it), and unreadable-path behavior (stop and ask the user to fix path/permissions).
- Applied symmetrically across both implementers to keep the text/binary contracts in lockstep, per the issue's lockstep requirement.

Closes #39

## Test plan
- [ ] `audit-skill` strict-definitions §3 (inputs declared) no longer flags the optional inputs in either implementer SKILL.md.
- [ ] Diff is limited to the two `Inputs` bullets in each file; no other content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)