### PR TITLE
story(issue-45): remove disable-model-invocation from new-go-*-file-library scaffolds

### DIFF
--- a/plugins/file-library/skills/new-go-binary-file-library-workspace/trigger-eval-issue-45/eval_set.json
+++ b/plugins/file-library/skills/new-go-binary-file-library-workspace/trigger-eval-issue-45/eval_set.json
@@ -1,0 +1,22 @@
+[
+  {"query": "I'm starting a Go library for parsing PNG image headers. Scaffold a new binary decoder/encoder package called `png` so I can fill in chunk handling later.", "should_trigger": true},
+  {"query": "scaffold a new go package called `gob2` for our custom binary serialization format - want the types/decoder/encoder layout with tests", "should_trigger": true},
+  {"query": "set up a fresh go pkg called `bson` for BSON. Standard binary format library layout please.", "should_trigger": true},
+  {"query": "kick off a new go binary format library called `flac` so I can fill in the FLAC frame format from the spec", "should_trigger": true},
+  {"query": "I need a starter go package for parsing zstd-compressed streams. call it `zstd`. just the boilerplate (types.go, decoder.go, encoder.go) and placeholder tests", "should_trigger": true},
+  {"query": "create a new go package for the Apache Parquet binary format - call it parquet. I'll implement the actual decode/encode logic later", "should_trigger": true},
+  {"query": "spin up a new binary format pkg in go for tiff files - i'll fill the actual decoder logic later. name it tiff", "should_trigger": true},
+  {"query": "bootstrap a new binary decoder/encoder go package called `cbor` with the standard scaffolding", "should_trigger": true},
+  {"query": "start fresh on a go pkg called `protobufwire` for the protobuf wire format - need the binary decode/encode skeleton", "should_trigger": true},
+  {"query": "make me a skeleton go package for parsing ELF binaries. name it elf. types/decoder/encoder pipeline.", "should_trigger": true},
+  {"query": "in my existing png package, add support for tRNS chunks to the decoder. encoder already handles them.", "should_trigger": false},
+  {"query": "scaffold a new go package called `yaml` for parsing yaml — it's a text format, tokenizer/parser/printer layout", "should_trigger": false},
+  {"query": "build me a go cli tool that reads PNG files and prints the metadata to stdout", "should_trigger": false},
+  {"query": "scaffold a python protobuf decoder library", "should_trigger": false},
+  {"query": "create a new go package for serializing my User struct to a binary cache - just gob encode/decode", "should_trigger": false},
+  {"query": "decode this base64 string in go and write the bytes to disk", "should_trigger": false},
+  {"query": "open binary.dat in go and check if the first 4 bytes are the magic number 0x89504E47", "should_trigger": false},
+  {"query": "implement a tcp server in go that accepts framed binary messages with a 4-byte length prefix", "should_trigger": false},
+  {"query": "use gzip to compress this slice of bytes in go and write to a file", "should_trigger": false},
+  {"query": "in my existing parquet package the encoder writes the wrong byte order for int64 columns. fix it.", "should_trigger": false}
+]

--- a/plugins/file-library/skills/new-go-binary-file-library-workspace/trigger-eval-issue-45/results.json
+++ b/plugins/file-library/skills/new-go-binary-file-library-workspace/trigger-eval-issue-45/results.json
@@ -1,0 +1,171 @@
+{
+  "skill_name": "new-go-binary-file-library",
+  "description": "Scaffold a new Go binary file library package with types, decoder, encoder, and tests. Use when the user asks to \"scaffold a new binary decoder/encoder package\" or \"start a new binary format library\". Skip when the user wants to add features to an existing binary package (use `implement-go-binary-file-library` instead) or when the target format is text, e.g. `tokenizer.go`/`parser.go`/`printer.go` (use `new-go-text-file-library` instead).",
+  "results": [
+    {
+      "query": "I'm starting a Go library for parsing PNG image headers. Scaffold a new binary decoder/encoder package called `png` so I can fill in chunk handling later.",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "scaffold a new go package called `gob2` for our custom binary serialization format - want the types/decoder/encoder layout with tests",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "set up a fresh go pkg called `bson` for BSON. Standard binary format library layout please.",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "kick off a new go binary format library called `flac` so I can fill in the FLAC frame format from the spec",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "I need a starter go package for parsing zstd-compressed streams. call it `zstd`. just the boilerplate (types.go, decoder.go, encoder.go) and placeholder tests",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "create a new go package for the Apache Parquet binary format - call it parquet. I'll implement the actual decode/encode logic later",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "spin up a new binary format pkg in go for tiff files - i'll fill the actual decoder logic later. name it tiff",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "bootstrap a new binary decoder/encoder go package called `cbor` with the standard scaffolding",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "start fresh on a go pkg called `protobufwire` for the protobuf wire format - need the binary decode/encode skeleton",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "make me a skeleton go package for parsing ELF binaries. name it elf. types/decoder/encoder pipeline.",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "in my existing png package, add support for tRNS chunks to the decoder. encoder already handles them.",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "scaffold a new go package called `yaml` for parsing yaml \u2014 it's a text format, tokenizer/parser/printer layout",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "build me a go cli tool that reads PNG files and prints the metadata to stdout",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "scaffold a python protobuf decoder library",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "create a new go package for serializing my User struct to a binary cache - just gob encode/decode",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "decode this base64 string in go and write the bytes to disk",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "open binary.dat in go and check if the first 4 bytes are the magic number 0x89504E47",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "implement a tcp server in go that accepts framed binary messages with a 4-byte length prefix",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "use gzip to compress this slice of bytes in go and write to a file",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "in my existing parquet package the encoder writes the wrong byte order for int64 columns. fix it.",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    }
+  ],
+  "summary": {
+    "total": 20,
+    "passed": 20,
+    "failed": 0
+  }
+}

--- a/plugins/file-library/skills/new-go-binary-file-library-workspace/trigger-eval-issue-45/run.log
+++ b/plugins/file-library/skills/new-go-binary-file-library-workspace/trigger-eval-issue-45/run.log
@@ -1,0 +1,22 @@
+Evaluating: Scaffold a new Go binary file library package with types, decoder, encoder, and tests. Use when the user asks to "scaffold a new binary decoder/encoder package" or "start a new binary format library". Skip when the user wants to add features to an existing binary package (use `implement-go-binary-file-library` instead) or when the target format is text, e.g. `tokenizer.go`/`parser.go`/`printer.go` (use `new-go-text-file-library` instead).
+Results: 20/20 passed
+  [PASS] rate=3/3 expected=True: I'm starting a Go library for parsing PNG image headers. Scaffold a ne
+  [PASS] rate=3/3 expected=True: scaffold a new go package called `gob2` for our custom binary serializ
+  [PASS] rate=3/3 expected=True: set up a fresh go pkg called `bson` for BSON. Standard binary format l
+  [PASS] rate=3/3 expected=True: kick off a new go binary format library called `flac` so I can fill in
+  [PASS] rate=3/3 expected=True: I need a starter go package for parsing zstd-compressed streams. call 
+  [PASS] rate=3/3 expected=True: create a new go package for the Apache Parquet binary format - call it
+  [PASS] rate=3/3 expected=True: spin up a new binary format pkg in go for tiff files - i'll fill the a
+  [PASS] rate=3/3 expected=True: bootstrap a new binary decoder/encoder go package called `cbor` with t
+  [PASS] rate=3/3 expected=True: start fresh on a go pkg called `protobufwire` for the protobuf wire fo
+  [PASS] rate=3/3 expected=True: make me a skeleton go package for parsing ELF binaries. name it elf. t
+  [PASS] rate=0/3 expected=False: in my existing png package, add support for tRNS chunks to the decoder
+  [PASS] rate=0/3 expected=False: scaffold a new go package called `yaml` for parsing yaml — it's a text
+  [PASS] rate=0/3 expected=False: build me a go cli tool that reads PNG files and prints the metadata to
+  [PASS] rate=0/3 expected=False: scaffold a python protobuf decoder library
+  [PASS] rate=0/3 expected=False: create a new go package for serializing my User struct to a binary cac
+  [PASS] rate=0/3 expected=False: decode this base64 string in go and write the bytes to disk
+  [PASS] rate=0/3 expected=False: open binary.dat in go and check if the first 4 bytes are the magic num
+  [PASS] rate=0/3 expected=False: implement a tcp server in go that accepts framed binary messages with 
+  [PASS] rate=0/3 expected=False: use gzip to compress this slice of bytes in go and write to a file
+  [PASS] rate=0/3 expected=False: in my existing parquet package the encoder writes the wrong byte order

--- a/plugins/file-library/skills/new-go-binary-file-library/SKILL.md
+++ b/plugins/file-library/skills/new-go-binary-file-library/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: new-go-binary-file-library
 description: Scaffold a new Go binary file library package with types, decoder, encoder, and tests. Use when the user asks to "scaffold a new binary decoder/encoder package" or "start a new binary format library". Skip when the user wants to add features to an existing binary package (use `implement-go-binary-file-library` instead) or when the target format is text, e.g. `tokenizer.go`/`parser.go`/`printer.go` (use `new-go-text-file-library` instead).
-disable-model-invocation: true
 argument-hint: "[package-name]"
 ---
 

--- a/plugins/file-library/skills/new-go-text-file-library-workspace/trigger-eval-issue-45/eval_set.json
+++ b/plugins/file-library/skills/new-go-text-file-library-workspace/trigger-eval-issue-45/eval_set.json
@@ -1,0 +1,22 @@
+[
+  {"query": "I'm starting a small Go library for parsing and formatting TOML files. Scaffold a new package called `toml` so I can start filling in the format details.", "should_trigger": true},
+  {"query": "scaffold a new go text file library package for the ini format. call it ini.", "should_trigger": true},
+  {"query": "kick off a new go package called `ldif` that I'll fill in later to parse LDAP LDIF files - tokenizer/parser/printer layout please", "should_trigger": true},
+  {"query": "i need to write a yaml parser in go from scratch. bootstrap a new pkg called yaml with the basic boilerplate (tokenizer, parser, printer, tests)", "should_trigger": true},
+  {"query": "spin up a fresh go pkg for parsing graphql schema documents. name it `graphql`. I'll fill in the real grammar from the spec afterward", "should_trigger": true},
+  {"query": "create a new go package called `css` for a CSS parser - I want the standard tokenizer/parser/printer skeleton with placeholder tests that pass", "should_trigger": true},
+  {"query": "start a new format library in Go for hcl (HashiCorp config language). I want to scaffold the package now and fill in the grammar over the next few days. call it hcl.", "should_trigger": true},
+  {"query": "Could you scaffold a new go package called `sql` so I can start implementing a SQL dialect parser? Want the empty tokenizer.go/parser.go/printer.go and tests in place.", "should_trigger": true},
+  {"query": "new go package for csv parsing pls. call it csv. just the boilerplate, i'll do the real parser logic", "should_trigger": true},
+  {"query": "set up a new tokenizer/parser/printer package in go called `protobuftext` for the protobuf text format", "should_trigger": true},
+  {"query": "in my existing toml package, please add support for inline tables to the parser. tokenizer already handles them.", "should_trigger": false},
+  {"query": "scaffold a new go package called `png` for parsing PNG files - it's a binary format, types/decoder/encoder", "should_trigger": false},
+  {"query": "create a new go web service called userapi with handlers for user CRUD endpoints", "should_trigger": false},
+  {"query": "scaffold a new Python library for parsing our internal log format", "should_trigger": false},
+  {"query": "in my existing yaml package, fix the parser bug where multi-line strings break when they contain colons", "should_trigger": false},
+  {"query": "set up a new go package for a redis client wrapper called redisx with a Get/Set API", "should_trigger": false},
+  {"query": "make a go CLI tool that converts toml files to json on stdout. just a single main.go is fine.", "should_trigger": false},
+  {"query": "read my config.toml and print the database section as a Go map[string]string", "should_trigger": false},
+  {"query": "explain the difference between a tokenizer and a lexer in compiler design", "should_trigger": false},
+  {"query": "write a small go function that strips html tags from a string using regexp", "should_trigger": false}
+]

--- a/plugins/file-library/skills/new-go-text-file-library-workspace/trigger-eval-issue-45/results.json
+++ b/plugins/file-library/skills/new-go-text-file-library-workspace/trigger-eval-issue-45/results.json
@@ -1,0 +1,171 @@
+{
+  "skill_name": "new-go-text-file-library",
+  "description": "Scaffold a new Go text file library package with tokenizer, parser, printer, and tests. Use when the user asks to \"start a new <format> library\" or \"scaffold a new <format> parser\". Skip when the user wants to add features to an existing text package (use `implement-go-text-file-library` instead) or when the target format is binary, e.g. `types.go`/`decoder.go`/`encoder.go` (use `new-go-binary-file-library` instead).",
+  "results": [
+    {
+      "query": "I'm starting a small Go library for parsing and formatting TOML files. Scaffold a new package called `toml` so I can start filling in the format details.",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "scaffold a new go text file library package for the ini format. call it ini.",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "kick off a new go package called `ldif` that I'll fill in later to parse LDAP LDIF files - tokenizer/parser/printer layout please",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "i need to write a yaml parser in go from scratch. bootstrap a new pkg called yaml with the basic boilerplate (tokenizer, parser, printer, tests)",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "spin up a fresh go pkg for parsing graphql schema documents. name it `graphql`. I'll fill in the real grammar from the spec afterward",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "create a new go package called `css` for a CSS parser - I want the standard tokenizer/parser/printer skeleton with placeholder tests that pass",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "start a new format library in Go for hcl (HashiCorp config language). I want to scaffold the package now and fill in the grammar over the next few days. call it hcl.",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "Could you scaffold a new go package called `sql` so I can start implementing a SQL dialect parser? Want the empty tokenizer.go/parser.go/printer.go and tests in place.",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "new go package for csv parsing pls. call it csv. just the boilerplate, i'll do the real parser logic",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "set up a new tokenizer/parser/printer package in go called `protobuftext` for the protobuf text format",
+      "should_trigger": true,
+      "trigger_rate": 1.0,
+      "triggers": 3,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "in my existing toml package, please add support for inline tables to the parser. tokenizer already handles them.",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "scaffold a new go package called `png` for parsing PNG files - it's a binary format, types/decoder/encoder",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "create a new go web service called userapi with handlers for user CRUD endpoints",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "scaffold a new Python library for parsing our internal log format",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "in my existing yaml package, fix the parser bug where multi-line strings break when they contain colons",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "set up a new go package for a redis client wrapper called redisx with a Get/Set API",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "make a go CLI tool that converts toml files to json on stdout. just a single main.go is fine.",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "read my config.toml and print the database section as a Go map[string]string",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "explain the difference between a tokenizer and a lexer in compiler design",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    },
+    {
+      "query": "write a small go function that strips html tags from a string using regexp",
+      "should_trigger": false,
+      "trigger_rate": 0.0,
+      "triggers": 0,
+      "runs": 3,
+      "pass": true
+    }
+  ],
+  "summary": {
+    "total": 20,
+    "passed": 20,
+    "failed": 0
+  }
+}

--- a/plugins/file-library/skills/new-go-text-file-library-workspace/trigger-eval-issue-45/run.log
+++ b/plugins/file-library/skills/new-go-text-file-library-workspace/trigger-eval-issue-45/run.log
@@ -1,0 +1,22 @@
+Evaluating: Scaffold a new Go text file library package with tokenizer, parser, printer, and tests. Use when the user asks to "start a new <format> library" or "scaffold a new <format> parser". Skip when the user wants to add features to an existing text package (use `implement-go-text-file-library` instead) or when the target format is binary, e.g. `types.go`/`decoder.go`/`encoder.go` (use `new-go-binary-file-library` instead).
+Results: 20/20 passed
+  [PASS] rate=3/3 expected=True: I'm starting a small Go library for parsing and formatting TOML files.
+  [PASS] rate=3/3 expected=True: scaffold a new go text file library package for the ini format. call i
+  [PASS] rate=3/3 expected=True: kick off a new go package called `ldif` that I'll fill in later to par
+  [PASS] rate=3/3 expected=True: i need to write a yaml parser in go from scratch. bootstrap a new pkg 
+  [PASS] rate=3/3 expected=True: spin up a fresh go pkg for parsing graphql schema documents. name it `
+  [PASS] rate=3/3 expected=True: create a new go package called `css` for a CSS parser - I want the sta
+  [PASS] rate=3/3 expected=True: start a new format library in Go for hcl (HashiCorp config language). 
+  [PASS] rate=3/3 expected=True: Could you scaffold a new go package called `sql` so I can start implem
+  [PASS] rate=3/3 expected=True: new go package for csv parsing pls. call it csv. just the boilerplate,
+  [PASS] rate=3/3 expected=True: set up a new tokenizer/parser/printer package in go called `protobufte
+  [PASS] rate=0/3 expected=False: in my existing toml package, please add support for inline tables to t
+  [PASS] rate=0/3 expected=False: scaffold a new go package called `png` for parsing PNG files - it's a 
+  [PASS] rate=0/3 expected=False: create a new go web service called userapi with handlers for user CRUD
+  [PASS] rate=0/3 expected=False: scaffold a new Python library for parsing our internal log format
+  [PASS] rate=0/3 expected=False: in my existing yaml package, fix the parser bug where multi-line strin
+  [PASS] rate=0/3 expected=False: set up a new go package for a redis client wrapper called redisx with 
+  [PASS] rate=0/3 expected=False: make a go CLI tool that converts toml files to json on stdout. just a 
+  [PASS] rate=0/3 expected=False: read my config.toml and print the database section as a Go map[string]
+  [PASS] rate=0/3 expected=False: explain the difference between a tokenizer and a lexer in compiler des
+  [PASS] rate=0/3 expected=False: write a small go function that strips html tags from a string using re

--- a/plugins/file-library/skills/new-go-text-file-library/SKILL.md
+++ b/plugins/file-library/skills/new-go-text-file-library/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: new-go-text-file-library
 description: Scaffold a new Go text file library package with tokenizer, parser, printer, and tests. Use when the user asks to "start a new <format> library" or "scaffold a new <format> parser". Skip when the user wants to add features to an existing text package (use `implement-go-text-file-library` instead) or when the target format is binary, e.g. `types.go`/`decoder.go`/`encoder.go` (use `new-go-binary-file-library` instead).
-disable-model-invocation: true
 argument-hint: "[package-name]"
 ---
 


### PR DESCRIPTION
## Summary

- Removes `disable-model-invocation: true` from `plugins/file-library/skills/new-go-text-file-library/SKILL.md` and `plugins/file-library/skills/new-go-binary-file-library/SKILL.md`. Per the [Claude Code skills docs](https://code.claude.com/docs/en/skills.md), preloading and model-invocation share the same gate, so the autonomous orchestrator agent in #20 cannot reach these scaffolds while the flag is set. Copilot CLI is unaffected — it has no equivalent flag.
- Preserves `argument-hint` so both skills remain slash-command-invokable, and preserves the existing "Use when… Skip when…" description-narrowing sentences (AC #3, #4).
- Adds a trigger-eval audit trail under each skill's `-workspace/trigger-eval-issue-45/` (10 should-trigger + 10 should-not-trigger queries per skill, including near-misses against the implementer skills and the cross-pipeline scaffold). Both skills score **20/20 PASS** against `claude-opus-4-7` at 3/3 trigger rate on positives and 0/3 on negatives, confirming the description alone gates correctly without the hard flag.

Closes #45. Unblocks #20.

## Test plan

- [x] `disable-model-invocation: true` removed from both `SKILL.md` files
- [x] `argument-hint: "[package-name]"` preserved in both
- [x] Description-narrowing language preserved
- [x] Trigger-eval positives all triggered 3/3 (10/10 per skill)
- [x] Trigger-eval near-miss negatives all triggered 0/3 (10/10 per skill), including: edits to existing packages (route to `implement-go-*-file-library`), wrong-pipeline scaffolds (route to the other `new-go-*-file-library`), non-Go scaffolds, CLI tools, single-file utilities, and explanatory questions
- [ ] Reviewer spot-checks the trigger-eval set in `*-workspace/trigger-eval-issue-45/eval_set.json` to confirm coverage feels right

🤖 Generated with [Claude Code](https://claude.com/claude-code)