### PR TITLE
story(issue-46): tighten _context_*.md format and cap size in implement-go-{text,binary}-file-library

### DIFF
--- a/plugins/file-library/skills/implement-go-binary-file-library/SKILL.md
+++ b/plugins/file-library/skills/implement-go-binary-file-library/SKILL.md
@@ -52,6 +52,45 @@ If `SPEC.md` is paired with `structures/<name>.md` or `encoding-tables/<name>.md
 
 Before launching subagents, grep the slices for `> **Ambiguity:**` callouts and surface them to the user.
 
+## Context summary format
+
+`_context_types.md` and `_context_decoder.md` exist so the next phase's subagent can rely on a small, deterministic snapshot in place of re-reading the upstream source files. Treat them as machine-readable, not narrative — a later subagent must be able to scan the file top-to-bottom and pick out symbols without parsing prose.
+
+**Strict format.** One symbol per line, signature only. No rationale, no examples, no commentary, no code bodies. The only structure permitted is the `## Section` headings shown below. Inside a struct or interface body, one field/method per line is still "one symbol per line"; that is fine. List items in the same order they appear in the source.
+
+**Hard cap: 400 lines per file.** If the summary you would write exceeds 400 lines, the phase's work-unit was sized too large — that is the whole point of the cap. Do not write a longer summary, do not abbreviate to fit, and do not split the summary across files. Stop, tell the user the request needs to be chunked (e.g., "implement the Header struct first, then come back for Records"), and re-launch the phase with the smaller scope.
+
+### `_context_types.md` shape
+
+```
+## Structs
+<every exported struct, in declaration order; one struct per block; fields one per line, signature only>
+
+## Enums
+<for each enum: the type declaration on its own line, then constants one per line, in declaration order>
+
+## Bit-field constants
+<for each flag type: the type declaration on its own line, then mask constants one per line>
+
+## Errors
+<every exported sentinel/typed error, one per line>
+```
+
+Omit any section that has no entries — do not write empty headings.
+
+### `_context_decoder.md` shape
+
+```
+## Decode
+func Decode(r io.Reader) (*File, error)
+
+## Byte order
+<big-endian | little-endian>
+
+## Exported decode helpers
+<every new exported decode method/function, one signature per line, in declaration order>
+```
+
 ## Phase order
 
 Run phases in order. Do not skip ahead. Each phase passes a small `_context_<phase>.md` summary forward.
@@ -68,7 +107,7 @@ Spawn a subagent with:
 
 Subagent must read its slices via `Read(path, offset, limit)`, write tests first (size checks via `binary.Size()`, `String()` round-trip for enums, error-chain assertions), confirm tests fail, implement types (every enum gets a `String()` method — non-negotiable; the first hex-dump test failure pays for it), then confirm `go test -race ./...` passes.
 
-When the subagent returns, run `go test -race ./...` yourself and write `_context_types.md` listing every exported type, enum value, and bit-field constant the next phases will need.
+When the subagent returns, run `go test -race ./...` yourself, then write `_context_types.md` in the strict format from the [Context summary format](#context-summary-format) section. Honor the 400-line cap; if the summary would exceed it, stop and ask the user to chunk the request before relaunching this phase.
 
 ### Phase 2 — decoder
 
@@ -81,7 +120,7 @@ Spawn a subagent with:
 
 Subagent must write decode tests first using hex byte literals + `bytes.NewReader`, including failure-path tests that assert the `FieldError → OffsetError → leaf` chain via `errors.Is`/`errors.As`. Every error site funnels through `d.wrapErr`. Each new structure gets its own `readX` method — don't inline record/header reading inside `readFile` even when it would compile, since it makes per-structure failure tests harder to target.
 
-When the subagent returns, run tests yourself and write `_context_decoder.md` capturing the public `Decode` signature, the byte order, and the names of any new exported decode helpers.
+When the subagent returns, run tests yourself, then write `_context_decoder.md` in the strict format from the [Context summary format](#context-summary-format) section. Honor the 400-line cap; if the summary would exceed it, stop and ask the user to chunk the request before relaunching this phase.
 
 ### Phase 3 — encoder
 

--- a/plugins/file-library/skills/implement-go-binary-file-library/evals/evals.json
+++ b/plugins/file-library/skills/implement-go-binary-file-library/evals/evals.json
@@ -22,7 +22,8 @@
         {"id": "tests-testify-require", "text": "tests use github.com/stretchr/testify/require"},
         {"id": "go-test-passes", "text": "go test -race ./... exits cleanly"},
         {"id": "no-scratch-files-left", "text": "no leftover _spec_*.md or _context_*.md scratch files in the package directory"},
-        {"id": "no-full-spec-copy", "text": "no copy of SPEC.md content was written to a scratch file in the package (e.g. _spec_structures.md should not exist)"}
+        {"id": "no-full-spec-copy", "text": "no copy of SPEC.md content was written to a scratch file in the package (e.g. _spec_structures.md should not exist)"},
+        {"id": "context-summary-spec-tightened", "text": "SKILL.md specifies, for both _context_types.md and _context_decoder.md, a strict signature-only format (no rationale, no examples), a hard 400-line cap, and a chunk-and-relaunch protocol when the cap would be exceeded (issue #46 acceptance)"}
       ]
     },
     {
@@ -45,7 +46,8 @@
         {"id": "errors-funnel-through-wrapErr", "text": "every new error site uses d.wrapErr / e.wrapErr"},
         {"id": "tests-parallel", "text": "all new tests call t.Parallel() at both function and subtest level"},
         {"id": "go-test-passes", "text": "go test -race ./... exits cleanly"},
-        {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content (e.g. _spec_structures.md) was written to the package"}
+        {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content (e.g. _spec_structures.md) was written to the package"},
+        {"id": "context-summary-spec-tightened", "text": "SKILL.md specifies, for both _context_types.md and _context_decoder.md, a strict signature-only format (no rationale, no examples), a hard 400-line cap, and a chunk-and-relaunch protocol when the cap would be exceeded (issue #46 acceptance)"}
       ]
     },
     {
@@ -67,7 +69,8 @@
         {"id": "errors-funnel-through-wrapErr", "text": "the CRC mismatch error funnels through d.wrapErr (FieldError → OffsetError → ErrChecksumMismatch)"},
         {"id": "tests-parallel", "text": "all new tests call t.Parallel() at both function and subtest level"},
         {"id": "go-test-passes", "text": "go test -race ./... exits cleanly"},
-        {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content was written to the package"}
+        {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content was written to the package"},
+        {"id": "context-summary-spec-tightened", "text": "SKILL.md specifies, for both _context_types.md and _context_decoder.md, a strict signature-only format (no rationale, no examples), a hard 400-line cap, and a chunk-and-relaunch protocol when the cap would be exceeded (issue #46 acceptance)"}
       ]
     }
   ]

--- a/plugins/file-library/skills/implement-go-binary-file-library/evals/grade.py
+++ b/plugins/file-library/skills/implement-go-binary-file-library/evals/grade.py
@@ -45,10 +45,42 @@ def has_t_parallel_at_both_levels(text: str) -> bool:
     return text.count("t.Parallel()") >= 2
 
 
+CONTEXT_FILENAMES = ("_context_types.md", "_context_decoder.md")
+
+
 def skill_md_text() -> str:
     """Read SKILL.md from the parent directory of this grade.py."""
     skill_md_path = Path(__file__).resolve().parent.parent / "SKILL.md"
     return skill_md_path.read_text() if skill_md_path.exists() else ""
+
+
+def extract_section(text: str, heading: str) -> str:
+    """Return the body of a top-level `## heading` section.
+
+    Walks lines and tracks fenced code blocks so that `## ...` markers inside
+    fenced templates (e.g. the literal `## Decode` line shown in the
+    context-summary shape templates) are not mistaken for the next section's
+    heading. Returns "" if the heading is not found.
+    """
+    lines = text.splitlines()
+    in_fence = False
+    start = -1
+    end = len(lines)
+    for i, line in enumerate(lines):
+        if line.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if start == -1:
+            if line.strip() == f"## {heading}":
+                start = i + 1
+        elif line.startswith("## "):
+            end = i
+            break
+    if start == -1:
+        return ""
+    return "\n".join(lines[start:end])
 
 
 def assertion_context_summary_spec_tightened() -> tuple[bool, str]:
@@ -58,27 +90,49 @@ def assertion_context_summary_spec_tightened() -> tuple[bool, str]:
     _context_*.md, (a) a strict signature-only format with no rationale or
     examples, (b) a hard 400-line cap, and (c) that exceeding the cap signals
     the work-unit was sized too large and should be chunked.
+
+    The check is anchored to the `## Context summary format` section so that
+    stray phrases elsewhere in the SKILL.md (e.g. an unrelated paragraph that
+    happens to contain "no examples") cannot cause a false positive. Both
+    per-file filenames must also appear inside that section, so the spec
+    cannot silently regress to covering only one of them.
     """
-    text = skill_md_text().lower()
+    text = skill_md_text()
+    section = extract_section(text, "Context summary format")
     findings = []
+
+    section_present = bool(section.strip())
+    findings.append(f"section_present={section_present}")
+    if not section_present:
+        return False, "; ".join(findings) + " (no `## Context summary format` section in SKILL.md)"
+
+    section_lower = section.lower()
 
     # (a) Strict signature-only format, no rationale, no examples.
     strict_format = (
-        "signature only" in text
-        and "no rationale" in text
-        and "no examples" in text
+        "signature only" in section_lower
+        and "no rationale" in section_lower
+        and "no examples" in section_lower
     )
     findings.append(f"strict_format={strict_format}")
 
     # (b) Hard 400-line cap.
-    line_cap = "400" in text and ("hard cap" in text or "400 lines" in text)
+    line_cap = "400" in section and ("hard cap" in section_lower or "400 lines" in section_lower)
     findings.append(f"400_line_cap={line_cap}")
 
     # (c) Cap overflow → chunk-and-relaunch protocol.
-    chunk_protocol = "sized too large" in text and "chunk" in text
+    chunk_protocol = "sized too large" in section_lower and "chunk" in section_lower
     findings.append(f"chunk_on_overflow={chunk_protocol}")
 
-    ok = strict_format and line_cap and chunk_protocol
+    # (d) Both per-file shapes are documented inside this section.
+    missing = [name for name in CONTEXT_FILENAMES if name not in section]
+    files_documented = not missing
+    findings.append(
+        f"files_documented={files_documented}"
+        + (f" (missing: {missing})" if missing else "")
+    )
+
+    ok = strict_format and line_cap and chunk_protocol and files_documented
     return ok, "; ".join(findings)
 
 

--- a/plugins/file-library/skills/implement-go-binary-file-library/evals/grade.py
+++ b/plugins/file-library/skills/implement-go-binary-file-library/evals/grade.py
@@ -45,6 +45,43 @@ def has_t_parallel_at_both_levels(text: str) -> bool:
     return text.count("t.Parallel()") >= 2
 
 
+def skill_md_text() -> str:
+    """Read SKILL.md from the parent directory of this grade.py."""
+    skill_md_path = Path(__file__).resolve().parent.parent / "SKILL.md"
+    return skill_md_path.read_text() if skill_md_path.exists() else ""
+
+
+def assertion_context_summary_spec_tightened() -> tuple[bool, str]:
+    """Verify SKILL.md specifies the tightened _context_*.md format and cap.
+
+    Acceptance from issue #46: the SKILL.md must specify, for each
+    _context_*.md, (a) a strict signature-only format with no rationale or
+    examples, (b) a hard 400-line cap, and (c) that exceeding the cap signals
+    the work-unit was sized too large and should be chunked.
+    """
+    text = skill_md_text().lower()
+    findings = []
+
+    # (a) Strict signature-only format, no rationale, no examples.
+    strict_format = (
+        "signature only" in text
+        and "no rationale" in text
+        and "no examples" in text
+    )
+    findings.append(f"strict_format={strict_format}")
+
+    # (b) Hard 400-line cap.
+    line_cap = "400" in text and ("hard cap" in text or "400 lines" in text)
+    findings.append(f"400_line_cap={line_cap}")
+
+    # (c) Cap overflow → chunk-and-relaunch protocol.
+    chunk_protocol = "sized too large" in text and "chunk" in text
+    findings.append(f"chunk_on_overflow={chunk_protocol}")
+
+    ok = strict_format and line_cap and chunk_protocol
+    return ok, "; ".join(findings)
+
+
 def assertion_eval0_header(asid: str, pkg: Path, run_dir: Path) -> tuple[bool, str]:
     types = read(pkg / "types.go")
     decoder = read(pkg / "decoder.go")
@@ -156,6 +193,9 @@ def assertion_eval0_header(asid: str, pkg: Path, run_dir: Path) -> tuple[bool, s
         leftovers = [p.name for p in pkg.glob("_spec*.md")]
         return len(leftovers) == 0, "no _spec*.md scratch copies" if not leftovers else f"spec copy leftover: {leftovers}"
 
+    if asid == "context-summary-spec-tightened":
+        return assertion_context_summary_spec_tightened()
+
     return False, f"unknown assertion id: {asid}"
 
 
@@ -249,6 +289,9 @@ def assertion_eval1_record(asid: str, pkg: Path, run_dir: Path) -> tuple[bool, s
         leftovers = [p.name for p in pkg.glob("_spec*.md")]
         return len(leftovers) == 0, "no _spec*.md leftovers" if not leftovers else f"leftover: {leftovers}"
 
+    if asid == "context-summary-spec-tightened":
+        return assertion_context_summary_spec_tightened()
+
     return False, f"unknown assertion id: {asid}"
 
 
@@ -319,6 +362,9 @@ def assertion_eval2_trailer(asid: str, pkg: Path, run_dir: Path) -> tuple[bool, 
     if asid == "no-full-spec-copy":
         leftovers = [p.name for p in pkg.glob("_spec*.md")]
         return len(leftovers) == 0, "no _spec*.md leftovers" if not leftovers else f"leftover: {leftovers}"
+
+    if asid == "context-summary-spec-tightened":
+        return assertion_context_summary_spec_tightened()
 
     return False, f"unknown assertion id: {asid}"
 

--- a/plugins/file-library/skills/implement-go-text-file-library/SKILL.md
+++ b/plugins/file-library/skills/implement-go-text-file-library/SKILL.md
@@ -50,6 +50,46 @@ If `SPEC.md` is paired with already-chunked `tokens/<name>.md` or `grammar/<name
 
 Before launching subagents, grep the slices for `> **Ambiguity:**` callouts and surface them to the user.
 
+## Context summary format
+
+`_context_tokens.md` and `_context_ast.md` exist so the next phase's subagent can rely on a small, deterministic snapshot in place of re-reading the upstream source files. Treat them as machine-readable, not narrative — a later subagent must be able to scan the file top-to-bottom and pick out symbols without parsing prose.
+
+**Strict format.** One symbol per line, signature only. No rationale, no examples, no commentary, no code bodies. The only structure permitted is the `## Section` headings shown below. Inside a struct or interface body, one field/method per line is still "one symbol per line"; that is fine. List items in the same order they appear in the source.
+
+**Hard cap: 400 lines per file.** If the summary you would write exceeds 400 lines, the phase's work-unit was sized too large — that is the whole point of the cap. Do not write a longer summary, do not abbreviate to fit, and do not split the summary across files. Stop, tell the user the request needs to be chunked (e.g., "tokenize comments and identifiers first, then come back for literals"), and re-launch the phase with the smaller scope.
+
+### `_context_tokens.md` shape
+
+```
+## TokenType
+<every constant from the TokenType const block, one per line, in declaration order>
+
+## Token
+type Token struct {
+    <one field per line, signature only>
+}
+```
+
+### `_context_ast.md` shape
+
+```
+## Parse
+func Parse(r io.Reader) (*File, error)
+
+## File
+type File struct {
+    <one field per line>
+}
+
+## Type
+type Type interface {
+    <one method signature per line>
+}
+
+## AST nodes
+<every concrete type that implements Type, in declaration order; one type per block; struct fields one per line>
+```
+
 ## Phase order
 
 Run phases in order. Do not skip ahead. Phase 1 writes `_context_tokens.md` (the `TokenType` constants and `Token` struct the next phases need); Phase 2 writes `_context_ast.md` (the `File` struct, `Type` interface, concrete AST nodes, and the `Parse()` signature). Phase 3 reads both and writes nothing forward.
@@ -66,7 +106,7 @@ Spawn a subagent with:
 
 Subagent must read its slices via `Read(path, offset, limit)`, write tokenizer tests first (table-driven, exact `Pos{Line, Column}` values, `collect` helper drains the `iter.Seq2`), confirm tests fail for the right reason, implement tokenizer changes following the closure pattern (capture state in returned action functions; never accumulate on the tokenizer struct), then confirm `(cd <package> && go test -race ./...)` passes.
 
-When the subagent returns, run `(cd <package> && go test -race ./...)` yourself and write `_context_tokens.md` listing the `TokenType` constants and `Token` struct definition the next phases will need.
+When the subagent returns, run `(cd <package> && go test -race ./...)` yourself, then write `_context_tokens.md` in the strict format from the [Context summary format](#context-summary-format) section. Honor the 400-line cap; if the summary would exceed it, stop and ask the user to chunk the request before relaunching this phase.
 
 ### Phase 2 — parser
 
@@ -79,7 +119,7 @@ Spawn a subagent with:
 
 Subagent must write parser tests first using the public `Parse()` function with real source strings — never construct AST nodes by hand for expectations (the empty-`File` scaffold case is the only exception). Confirm tests fail for the right reason. Implement parser changes; for any complex type (nested members, repetition, alternation), use the **inner action loop pattern** with one `parserAction[*T]` per state — flat for-loops with switches accrete and become unmaintainable, so this is a hard rule. Use `p.expect(types...)` everywhere the grammar requires a specific token; never inline the type check.
 
-When the subagent returns, run tests yourself and write `_context_ast.md` capturing the `File` struct, the `Type` interface, every concrete AST type that implements it, and the `Parse()` signature.
+When the subagent returns, run tests yourself, then write `_context_ast.md` in the strict format from the [Context summary format](#context-summary-format) section. Honor the 400-line cap; if the summary would exceed it, stop and ask the user to chunk the request before relaunching this phase.
 
 ### Phase 3 — printer
 

--- a/plugins/file-library/skills/implement-go-text-file-library/evals/evals.json
+++ b/plugins/file-library/skills/implement-go-text-file-library/evals/evals.json
@@ -23,7 +23,8 @@
         {"id": "tests-testify-require", "text": "tests use github.com/stretchr/testify/require"},
         {"id": "go-test-passes", "text": "go test -race ./... exits cleanly"},
         {"id": "no-scratch-files-left", "text": "no leftover _spec_*.md or _context_*.md scratch files in the package directory"},
-        {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content was written to the package (e.g. _spec_tokens.md should not exist)"}
+        {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content was written to the package (e.g. _spec_tokens.md should not exist)"},
+        {"id": "context-summary-spec-tightened", "text": "SKILL.md specifies, for both _context_tokens.md and _context_ast.md, a strict signature-only format (no rationale, no examples), a hard 400-line cap, and a chunk-and-relaunch protocol when the cap would be exceeded (issue #46 acceptance)"}
       ]
     },
     {
@@ -44,7 +45,8 @@
         {"id": "printer-round-trip-test", "text": "printer_test.go has at least one round-trip test covering a block (Parse → Print → Parse → require.Equal)"},
         {"id": "tests-parallel", "text": "all new tests call t.Parallel() at both function and subtest level"},
         {"id": "go-test-passes", "text": "go test -race ./... exits cleanly"},
-        {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content was written to the package"}
+        {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content was written to the package"},
+        {"id": "context-summary-spec-tightened", "text": "SKILL.md specifies, for both _context_tokens.md and _context_ast.md, a strict signature-only format (no rationale, no examples), a hard 400-line cap, and a chunk-and-relaunch protocol when the cap would be exceeded (issue #46 acceptance)"}
       ]
     },
     {
@@ -64,7 +66,8 @@
         {"id": "tokenizer-test-comment-pos", "text": "tokenizer_test.go has a test for a comment token that asserts an exact Pos value for the comment"},
         {"id": "tests-parallel", "text": "all new tests call t.Parallel() at both function and subtest level"},
         {"id": "go-test-passes", "text": "go test -race ./... exits cleanly"},
-        {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content was written to the package"}
+        {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content was written to the package"},
+        {"id": "context-summary-spec-tightened", "text": "SKILL.md specifies, for both _context_tokens.md and _context_ast.md, a strict signature-only format (no rationale, no examples), a hard 400-line cap, and a chunk-and-relaunch protocol when the cap would be exceeded (issue #46 acceptance)"}
       ]
     }
   ]

--- a/plugins/file-library/skills/implement-go-text-file-library/evals/grade.py
+++ b/plugins/file-library/skills/implement-go-text-file-library/evals/grade.py
@@ -35,10 +35,42 @@ def has_t_parallel_at_both_levels(text: str) -> bool:
     return text.count("t.Parallel()") >= 2
 
 
+CONTEXT_FILENAMES = ("_context_tokens.md", "_context_ast.md")
+
+
 def skill_md_text() -> str:
     """Read SKILL.md from the parent directory of this grade.py."""
     skill_md_path = Path(__file__).resolve().parent.parent / "SKILL.md"
     return skill_md_path.read_text() if skill_md_path.exists() else ""
+
+
+def extract_section(text: str, heading: str) -> str:
+    """Return the body of a top-level `## heading` section.
+
+    Walks lines and tracks fenced code blocks so that `## ...` markers inside
+    fenced templates (e.g. the literal `## TokenType` line shown in the
+    context-summary shape templates) are not mistaken for the next section's
+    heading. Returns "" if the heading is not found.
+    """
+    lines = text.splitlines()
+    in_fence = False
+    start = -1
+    end = len(lines)
+    for i, line in enumerate(lines):
+        if line.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if start == -1:
+            if line.strip() == f"## {heading}":
+                start = i + 1
+        elif line.startswith("## "):
+            end = i
+            break
+    if start == -1:
+        return ""
+    return "\n".join(lines[start:end])
 
 
 def assertion_context_summary_spec_tightened() -> tuple[bool, str]:
@@ -48,27 +80,49 @@ def assertion_context_summary_spec_tightened() -> tuple[bool, str]:
     _context_*.md, (a) a strict signature-only format with no rationale or
     examples, (b) a hard 400-line cap, and (c) that exceeding the cap signals
     the work-unit was sized too large and should be chunked.
+
+    The check is anchored to the `## Context summary format` section so that
+    stray phrases elsewhere in the SKILL.md (e.g. an unrelated paragraph that
+    happens to contain "no examples") cannot cause a false positive. Both
+    per-file filenames must also appear inside that section, so the spec
+    cannot silently regress to covering only one of them.
     """
-    text = skill_md_text().lower()
+    text = skill_md_text()
+    section = extract_section(text, "Context summary format")
     findings = []
+
+    section_present = bool(section.strip())
+    findings.append(f"section_present={section_present}")
+    if not section_present:
+        return False, "; ".join(findings) + " (no `## Context summary format` section in SKILL.md)"
+
+    section_lower = section.lower()
 
     # (a) Strict signature-only format, no rationale, no examples.
     strict_format = (
-        "signature only" in text
-        and "no rationale" in text
-        and "no examples" in text
+        "signature only" in section_lower
+        and "no rationale" in section_lower
+        and "no examples" in section_lower
     )
     findings.append(f"strict_format={strict_format}")
 
     # (b) Hard 400-line cap.
-    line_cap = "400" in text and ("hard cap" in text or "400 lines" in text)
+    line_cap = "400" in section and ("hard cap" in section_lower or "400 lines" in section_lower)
     findings.append(f"400_line_cap={line_cap}")
 
     # (c) Cap overflow → chunk-and-relaunch protocol.
-    chunk_protocol = "sized too large" in text and "chunk" in text
+    chunk_protocol = "sized too large" in section_lower and "chunk" in section_lower
     findings.append(f"chunk_on_overflow={chunk_protocol}")
 
-    ok = strict_format and line_cap and chunk_protocol
+    # (d) Both per-file shapes are documented inside this section.
+    missing = [name for name in CONTEXT_FILENAMES if name not in section]
+    files_documented = not missing
+    findings.append(
+        f"files_documented={files_documented}"
+        + (f" (missing: {missing})" if missing else "")
+    )
+
+    ok = strict_format and line_cap and chunk_protocol and files_documented
     return ok, "; ".join(findings)
 
 

--- a/plugins/file-library/skills/implement-go-text-file-library/evals/grade.py
+++ b/plugins/file-library/skills/implement-go-text-file-library/evals/grade.py
@@ -35,6 +35,43 @@ def has_t_parallel_at_both_levels(text: str) -> bool:
     return text.count("t.Parallel()") >= 2
 
 
+def skill_md_text() -> str:
+    """Read SKILL.md from the parent directory of this grade.py."""
+    skill_md_path = Path(__file__).resolve().parent.parent / "SKILL.md"
+    return skill_md_path.read_text() if skill_md_path.exists() else ""
+
+
+def assertion_context_summary_spec_tightened() -> tuple[bool, str]:
+    """Verify SKILL.md specifies the tightened _context_*.md format and cap.
+
+    Acceptance from issue #46: the SKILL.md must specify, for each
+    _context_*.md, (a) a strict signature-only format with no rationale or
+    examples, (b) a hard 400-line cap, and (c) that exceeding the cap signals
+    the work-unit was sized too large and should be chunked.
+    """
+    text = skill_md_text().lower()
+    findings = []
+
+    # (a) Strict signature-only format, no rationale, no examples.
+    strict_format = (
+        "signature only" in text
+        and "no rationale" in text
+        and "no examples" in text
+    )
+    findings.append(f"strict_format={strict_format}")
+
+    # (b) Hard 400-line cap.
+    line_cap = "400" in text and ("hard cap" in text or "400 lines" in text)
+    findings.append(f"400_line_cap={line_cap}")
+
+    # (c) Cap overflow → chunk-and-relaunch protocol.
+    chunk_protocol = "sized too large" in text and "chunk" in text
+    findings.append(f"chunk_on_overflow={chunk_protocol}")
+
+    ok = strict_format and line_cap and chunk_protocol
+    return ok, "; ".join(findings)
+
+
 def assertion_eval0_string_record(asid: str, pkg: Path, run_dir: Path) -> tuple[bool, str]:
     tokenizer = read(pkg / "tokenizer.go")
     parser = read(pkg / "parser.go")
@@ -142,6 +179,9 @@ def assertion_eval0_string_record(asid: str, pkg: Path, run_dir: Path) -> tuple[
         leftovers = [p.name for p in pkg.glob("_spec*.md")]
         return len(leftovers) == 0, "no _spec*.md scratch copies" if not leftovers else f"spec copy leftover: {leftovers}"
 
+    if asid == "context-summary-spec-tightened":
+        return assertion_context_summary_spec_tightened()
+
     return False, f"unknown assertion id: {asid}"
 
 
@@ -231,6 +271,9 @@ def assertion_eval1_block(asid: str, pkg: Path, run_dir: Path) -> tuple[bool, st
         leftovers = [p.name for p in pkg.glob("_spec*.md")]
         return len(leftovers) == 0, "no _spec*.md leftovers" if not leftovers else f"leftover: {leftovers}"
 
+    if asid == "context-summary-spec-tightened":
+        return assertion_context_summary_spec_tightened()
+
     return False, f"unknown assertion id: {asid}"
 
 
@@ -309,6 +352,9 @@ def assertion_eval2_comments(asid: str, pkg: Path, run_dir: Path) -> tuple[bool,
     if asid == "no-full-spec-copy":
         leftovers = [p.name for p in pkg.glob("_spec*.md")]
         return len(leftovers) == 0, "no _spec*.md leftovers" if not leftovers else f"leftover: {leftovers}"
+
+    if asid == "context-summary-spec-tightened":
+        return assertion_context_summary_spec_tightened()
 
     return False, f"unknown assertion id: {asid}"
 


### PR DESCRIPTION
Closes #46.

## Summary
- Both `implement-go-text-file-library` and `implement-go-binary-file-library` SKILL.md files gain a new `## Context summary format` section that defines, for each inter-phase `_context_*.md` summary: a strict signature-only format (no rationale, no examples, no commentary, no code bodies), a hard 400-line cap, and an abort-and-chunk protocol when the cap would be exceeded.
- Per-file shape templates spell out the layout for `_context_tokens.md` / `_context_ast.md` (text) and `_context_types.md` / `_context_decoder.md` (binary), so a later phase's subagent can rely on them as a deterministic substitute for re-reading the upstream source files.
- The Phase 1 / Phase 2 paragraphs that previously said "list every TokenType constant…" / "capture the File struct…" now point at the new section and explicitly call out the cap.
- Eval suites gain a `context-summary-spec-tightened` assertion in each `grade.py` + `evals.json` pair (3 evals × 2 skills = 6 new assertion entries) that reads each skill's SKILL.md and verifies the three acceptance properties from the issue.

## Test plan
- [x] New `assertion_context_summary_spec_tightened()` passes against the updated SKILL.md content (verified for both skills)
- [x] Same assertion fails against simulated pre-issue-46 SKILL.md content (regression-detection sanity check)
- [ ] Re-run a full eval iteration on a representative spec to confirm the orchestrator follows the new format and respects the cap in practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)