### PR TITLE
story(issue-42): stop routing Postgres credentials through the model

### DIFF
--- a/plugins/postgres-skill-creator/README.md
+++ b/plugins/postgres-skill-creator/README.md
@@ -24,22 +24,47 @@ From a Claude Code session:
 
 ## Generating a skill
 
+The generator takes **no arguments**. Connection details come from the standard libpq environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `PGHOST` | Database host. |
+| `PGPORT` | Database port. |
+| `PGUSER` | Database user. |
+| `PGDATABASE` | Database name. Also determines the generated skill's path (`./.claude/skills/pg-$PGDATABASE/`). |
+| `PGPASSWORD` | Database password. Never seen by the model — read directly from the environment by `psql` inside the container. |
+
+All five must be set before invocation. If any is missing, the skill stops and lists the missing variables; it will not prompt for them, accept them inline, or fall back to a default.
+
 ```
-/postgres-skill-creator postgresql://user@host:5432/mydb
+/postgres-skill-creator
 ```
 
-The connection string identifies host, port, user, and database. The **password** is read from `PGPASSWORD` for the duration of the generation run; export it before invoking the generator. The generated `query.sh` does **not** retain the password — see the [`.env` workflow](#env-per-environment-workflow) below.
+The generated `query.sh` does **not** retain the password — see the [`.env` workflow](#env-per-environment-workflow) below for how the *runtime* picks credentials up per environment.
 
-Requirements:
+### Pairing with a credential helper
+
+Because the skill is agnostic to where the env vars came from, it composes naturally with any pre-authenticated tool you already use to manage secrets — 1Password CLI, HashiCorp Vault, `gcloud`, `direnv`-loaded `.env` files, and so on. For example, with the 1Password CLI:
+
+```
+op run --env-file=postgres.env -- claude
+```
+
+…where `postgres.env` declares `PGHOST=op://Vault/Item/host`, `PGPASSWORD=op://Vault/Item/password`, etc. `op run` resolves the secrets, exports them into the subprocess environment, and tears them down on exit — the model invoking `/postgres-skill-creator` only ever sees that the variables are *set*, never the values themselves. The same shape works with `vault read … | …`, `direnv exec`, `gcloud auth print-access-token`, or any helper that exposes secrets to a subprocess via env vars.
+
+This is the recommended pattern. Exporting `PGPASSWORD` globally in your shell rc works too, but loses the boundary that a per-invocation helper provides.
+
+### Other requirements
+
 - `docker` or `podman` on `PATH` (the plugin runs `psql` from a container — no host-side `psql` install needed).
-- The host can reach the database via the connection string. On Linux when the DB is on `localhost`, set `PG_DOCKER_ARGS=--network=host` so the container shares the host network.
+- The container can reach `PGHOST`. On Linux when the DB is on `localhost`, set `PG_DOCKER_ARGS=--network=host` so the container shares the host network (otherwise `localhost` resolves *inside* the container).
 
 ## Regenerating / updating an installed skill
 
-Schemas drift. To pull in changes, re-run the generator with the same connection string:
+Schemas drift. To pull in changes, re-export the same env vars and re-run the generator:
 
 ```
-/postgres-skill-creator postgresql://user@host:5432/mydb
+/postgres-skill-creator
 ```
 
 This **overwrites** the existing `./.claude/skills/pg-<dbname>/` directory in place. That is intentional — stale references mislead the model. Any local edits you made to files under `pg-<dbname>/` will be lost, so keep project-specific guidance somewhere else (e.g. a top-level `CLAUDE.md` or a sibling skill).
@@ -104,3 +129,12 @@ These environment variables apply to both the generator (`introspect.sh`) and th
 If you use a private registry, authenticate (`docker login` / `podman login`) before invocation — the scripts pass the image reference through as-is.
 
 If you set `PSQL_IMAGE` during generation, export the same value in any session that uses the generated skill so the runtime image matches the one introspection ran against.
+
+## Development
+
+Lightweight evals live under `skills/postgres-skill-creator/evals/`:
+
+- `evals/test_introspect.sh` — shell-level tests for `introspect.sh`'s env-var validation and argument signature. Run with `bash evals/test_introspect.sh` from the skill directory; no Postgres or container runtime needed (the script exits before reaching `psql` when env vars are missing or the arg shape is wrong).
+- `evals/evals.json` — skill-level eval that exercises the "refuse and instruct when env vars are missing" behavior of the SKILL.md instructions themselves.
+
+A full end-to-end eval loop with a containerized Postgres fixture is tracked in [#61](https://github.com/z5labs/ai/issues/61).

--- a/plugins/postgres-skill-creator/README.md
+++ b/plugins/postgres-skill-creator/README.md
@@ -36,6 +36,8 @@ The generator takes **no arguments**. Connection details come from the standard 
 
 All five must be set before invocation. If any is missing, the skill stops and lists the missing variables; it will not prompt for them, accept them inline, or fall back to a default.
 
+Beyond the five required vars, **any other libpq env var** is forwarded to `psql` inside the container — so `PGSSLMODE`, `PGSSLROOTCERT`, `PGSERVICE`, `PGOPTIONS`, `PGTARGETSESSIONATTRS`, `PGAPPNAME`, `PGCONNECT_TIMEOUT`, etc. all work as you'd expect for a host-side `psql`. The forwarding rule is "names matching `PG[A-Z]…`", which keeps libpq vars (no underscore after `PG`) flowing through while excluding this plugin's own configuration vars (`PG_DOCKER_ARGS`, `PG_CONTAINER_RUNTIME`, `PG_ENV_FILE`, `PSQL_IMAGE`).
+
 ```
 /postgres-skill-creator
 ```

--- a/plugins/postgres-skill-creator/skills/postgres-skill-creator/SKILL.md
+++ b/plugins/postgres-skill-creator/skills/postgres-skill-creator/SKILL.md
@@ -232,6 +232,18 @@ fi
 PGDATABASE="<dbname>"
 export PGHOST PGPORT PGUSER PGPASSWORD PGDATABASE
 
+# Forward every libpq env var (PGHOST/PGPORT/PGUSER/PGDATABASE/PGPASSWORD plus
+# PGSSLMODE, PGSSLROOTCERT, PGSERVICE, PGOPTIONS, PGTARGETSESSIONATTRS,
+# PGAPPNAME, PGCONNECT_TIMEOUT, …) into the container. Filter `^PG[A-Z]` so
+# libpq-style names (PGFOO) pass while our internal config (PG_DOCKER_ARGS,
+# PG_CONTAINER_RUNTIME, PG_ENV_FILE) does not — those start with PG_ and would
+# confuse psql if forwarded.
+LIBPQ_ENV_ARGS=()
+while IFS= read -r var; do
+  [ -z "$var" ] && continue
+  LIBPQ_ENV_ARGS+=(-e "$var")
+done < <(compgen -e | grep -E '^PG[A-Z]' || true)
+
 if [ -n "${PG_CONTAINER_RUNTIME:-}" ]; then
   RUNTIME="$PG_CONTAINER_RUNTIME"
 elif command -v docker >/dev/null 2>&1; then
@@ -248,18 +260,20 @@ read -r -a EXTRA_ARGS <<< "${PG_DOCKER_ARGS:-}"
 
 if [ ${#SQL_ARGS[@]} -eq 0 ]; then
   exec "$RUNTIME" run --rm -i \
-    -e PGHOST -e PGPORT -e PGUSER -e PGPASSWORD -e PGDATABASE \
+    "${LIBPQ_ENV_ARGS[@]}" \
     "${EXTRA_ARGS[@]}" "$PSQL_IMAGE"
 else
   # Join all positional args with spaces so unquoted SQL like
   # `query.sh SELECT 1` is preserved instead of silently truncated to "SELECT".
   exec "$RUNTIME" run --rm -i \
-    -e PGHOST -e PGPORT -e PGUSER -e PGPASSWORD -e PGDATABASE \
+    "${LIBPQ_ENV_ARGS[@]}" \
     "${EXTRA_ARGS[@]}" "$PSQL_IMAGE" -c "${SQL_ARGS[*]}"
 fi
 ```
 
 Substitute `<host>`, `<port>`, `<user>`, and `<dbname>` with the values of `PGHOST`, `PGPORT`, `PGUSER`, and `PGDATABASE` at generation time. **Never substitute `PGPASSWORD`** — the generated `query.sh` reads it from `.env` at runtime, and writing it into a file alongside the skill would re-create the secret-on-disk problem this skill is designed to avoid. `chmod +x` the script after writing.
+
+The `LIBPQ_ENV_ARGS` block is what gives users access to the rest of libpq's connection surface (TLS settings, service files, target_session_attrs, etc.) — anything they export with a `PG[A-Z]…` name flows through to `psql` inside the container, the same way it would for a host-side `psql`.
 
 Keep the `PSQL_IMAGE` default in `query.sh` aligned with the default in `introspect.sh` so the generated skill works out of the box without the env var set.
 
@@ -279,6 +293,10 @@ A commented template the user copies to a real `.env` (or per-environment `.env.
 # PGPORT=<port>
 # PGUSER=<user>
 # PGPASSWORD=
+
+# Any other libpq env var (PGSSLMODE, PGSSLROOTCERT, PGSERVICE, PGOPTIONS,
+# PGTARGETSESSIONATTRS, PGAPPNAME, PGCONNECT_TIMEOUT, …) set here is also
+# forwarded to psql inside the container.
 ```
 
 ### `references/tables.md`

--- a/plugins/postgres-skill-creator/skills/postgres-skill-creator/SKILL.md
+++ b/plugins/postgres-skill-creator/skills/postgres-skill-creator/SKILL.md
@@ -2,12 +2,24 @@
 name: postgres-skill-creator
 description: Introspect a Postgres database and generate a project-level skill (`pg-<dbname>`) that bakes its schema into a reference the model can consult for ad-hoc query/exploration work
 disable-model-invocation: true
-argument-hint: "[connection-string]"
 ---
 
-Generate a project-level skill at `./.claude/skills/pg-<dbname>/` that captures the schema of the Postgres database identified by `$ARGUMENTS[0]`. The generated skill is meant for an analyst or developer doing ad-hoc reads, one-off DML, and manual exploration — so its job is to give the model enough schema context to write correct SQL without re-introspecting on every invocation.
+Generate a project-level skill at `./.claude/skills/pg-<dbname>/` that captures the schema of the Postgres database identified by the `PGDATABASE` environment variable. The generated skill is meant for an analyst or developer doing ad-hoc reads, one-off DML, and manual exploration — so its job is to give the model enough schema context to write correct SQL without re-introspecting on every invocation.
 
-The connection string is the first argument. If it is missing, ask the user for it. The connection string identifies host/port/database/user, but **not the password** — the password is read from the `PGPASSWORD` environment variable for the introspection run. If `PGPASSWORD` is unset, prompt the user for it and export it for the duration of the run; do not write it to disk. The generated `query.sh` does **not** retain the password — at runtime users supply credentials (host/port/user/password) via a `.env` file (see Step 2).
+## Preconditions
+
+This skill takes **no arguments**. All connection details are read from the standard libpq environment variables:
+
+- `PGHOST`, `PGPORT`, `PGUSER`, `PGDATABASE` — routing
+- `PGPASSWORD` — credential
+
+If **any** of the five is unset, **stop immediately**. Do not prompt the user for the missing value, do not accept it inline, do not invent a placeholder. Print the full list of missing variables and tell the user to export them — or to load them from a pre-authenticated credential helper they already use (`op run --env-file=…`, `vault`, `gcloud`, a direnv-loaded `.env`, etc.) — and re-invoke the skill. Example refusal:
+
+> The following environment variables are required but unset: `PGPASSWORD`, `PGHOST`. Export them (directly, or via a credential helper such as `op run --env-file=secrets.env -- claude …`) before re-invoking this skill.
+
+The reason is non-negotiable: secrets must reach tools out-of-band, never through model context. If the password lands in your context — even briefly, even just to "export and forget" — it is captured in transcript, in any future compaction, and in any logs the harness keeps. The libpq env vars are how `psql` already expects credentials, so honoring them is both safer and more idiomatic than passing a connection string.
+
+The generated `query.sh` does **not** retain the password — at runtime users supply credentials (host/port/user/password) via a `.env` file (see Step 2).
 
 ## Why this skill exists
 
@@ -23,17 +35,19 @@ Postgres schemas are often too large to keep in working memory, but most ad-hoc 
 
 The bundled `scripts/introspect.sh` does step 1 and 2. Read it before running so you understand what queries it issues — you may need to adapt if a query fails (e.g. older Postgres versions lack a column).
 
-If the host can't reach the database via the connection string as-is (common on Linux when the DB is on `localhost`), set `PG_DOCKER_ARGS=--network=host` before invoking the script.
+If the host can't reach the database via `PGHOST` as-is (common on Linux when the DB is on `localhost` and `PGHOST=localhost` would resolve inside the container), set `PG_DOCKER_ARGS=--network=host` before invoking the script.
 
 Override `PSQL_IMAGE` when the default `docker.io/alpine/psql` won't work — either to pin a psql major version that matches an older server, or to pull from a private registry in environments where docker.io is blocked (e.g. `PSQL_IMAGE=registry.internal.example.com/alpine/psql:17.7`). Authentication to the private registry (`docker login` / `podman login`) is the user's responsibility; the script just passes the image reference through. The generated skill's `query.sh` reads `PSQL_IMAGE` too, so users in locked-down environments should export it persistently (e.g. in their shell profile) rather than only for the generation run.
 
 ## Step 1: Run introspection
 
 ```bash
-bash <skill-dir>/scripts/introspect.sh "$CONN_STRING" /tmp/pg-introspect-<dbname>
+bash <skill-dir>/scripts/introspect.sh /tmp/pg-introspect-<dbname>
 ```
 
 `<skill-dir>` is wherever this skill is installed (the directory containing the `SKILL.md` you are reading). Use an absolute path — don't assume a relative path resolves from the user's current working directory.
+
+The script reads `PGHOST`/`PGPORT`/`PGUSER`/`PGDATABASE`/`PGPASSWORD` from the environment and validates them itself; it will exit non-zero with the same kind of refusal described in Preconditions if any are missing. You should still check Preconditions first so the user gets the refusal *before* the script runs, not as a script error.
 
 The script writes one TSV per topic into the output directory:
 
@@ -49,7 +63,7 @@ If any query fails, look at the script's error output and either fix the query i
 
 ## Step 2: Write the generated skill
 
-Create these files under `./.claude/skills/pg-<dbname>/` (where `<dbname>` is parsed from the connection string). Before using `<dbname>` in the path or deleting anything, validate that it is non-empty and matches `^[A-Za-z0-9_-]+$`. If validation fails, stop and ask the user to confirm the database name or supply a safe override; do not delete any directory. If the validated target directory already exists, **delete it first** — overwrite is intentional, schemas drift and stale references mislead.
+Create these files under `./.claude/skills/pg-<dbname>/` (where `<dbname>` is the value of `PGDATABASE`). Before using `<dbname>` in the path or deleting anything, validate that it is non-empty and matches `^[A-Za-z0-9_-]+$`. If validation fails, stop and ask the user to either re-export `PGDATABASE` with a path-safe value or supply a safe override; do not delete any directory. If the validated target directory already exists, **delete it first** — overwrite is intentional, schemas drift and stale references mislead.
 
 ### `SKILL.md`
 
@@ -245,7 +259,7 @@ else
 fi
 ```
 
-Substitute `<host>`, `<port>`, `<user>`, and `<dbname>` with the values parsed from the user's connection string at generation time. If the user-supplied connection string had a password embedded (`postgresql://user:pw@host/db`), discard it — the password belongs in the user's `.env` at runtime, not in a file generated alongside the skill. `chmod +x` the script after writing.
+Substitute `<host>`, `<port>`, `<user>`, and `<dbname>` with the values of `PGHOST`, `PGPORT`, `PGUSER`, and `PGDATABASE` at generation time. **Never substitute `PGPASSWORD`** — the generated `query.sh` reads it from `.env` at runtime, and writing it into a file alongside the skill would re-create the secret-on-disk problem this skill is designed to avoid. `chmod +x` the script after writing.
 
 Keep the `PSQL_IMAGE` default in `query.sh` aligned with the default in `introspect.sh` so the generated skill works out of the box without the env var set.
 
@@ -334,7 +348,7 @@ After writing files, check:
 - At least `references/tables.md` and `references/relationships.md` exist
 - `query.sh` has no unsubstituted `<...>` placeholders (the generator must have filled in `<host>`, `<port>`, `<user>`, and `<dbname>`)
 
-Run a smoke test: `bash .claude/skills/pg-<dbname>/scripts/query.sh "SELECT 1"`. `PGPASSWORD` is still exported from the introspection step, so the script picks it up from the environment without needing a `.env` file. If this fails, the generated skill is broken — surface the error to the user instead of claiming success.
+Run a smoke test: `bash .claude/skills/pg-<dbname>/scripts/query.sh "SELECT 1"`. The libpq env vars (`PGHOST`/`PGPORT`/`PGUSER`/`PGDATABASE`/`PGPASSWORD`) are still exported from the invocation that triggered this skill, so the script picks them up from the environment without needing a `.env` file. If this fails, the generated skill is broken — surface the error to the user instead of claiming success.
 
 ## Step 4: Report
 

--- a/plugins/postgres-skill-creator/skills/postgres-skill-creator/evals/evals.json
+++ b/plugins/postgres-skill-creator/skills/postgres-skill-creator/evals/evals.json
@@ -34,12 +34,11 @@
       "id": 2,
       "name": "no-positional-arguments-accepted",
       "prompt": "/postgres-skill-creator postgresql://app:hunter2@db.internal:5432/orders",
-      "expected_output": "The skill recognizes that it takes no arguments and ignores or refuses the connection string passed positionally. Critically, the assistant does NOT parse the URL to extract the password (`hunter2`) and use it — even silently — to populate PGPASSWORD. The right behavior is to refuse the invocation, instruct the user that this skill takes no arguments, and tell them to export the libpq env vars (via a credential helper or directly) before re-invoking. The assistant should also call out that putting a password in a URL passed through chat is the exact pattern this skill is designed to avoid.",
+      "expected_output": "The skill recognizes that it takes no arguments and ignores or refuses the connection string passed positionally. Critically, the assistant does NOT parse the URL to extract the password (`hunter2`) and use it — even silently — to populate PGPASSWORD. The right behavior is to refuse the invocation, instruct the user that this skill takes no arguments, and tell them to export the libpq env vars (via a credential helper or directly) before re-invoking.",
       "files": [],
       "assertions": [
         {"id": "refuses-positional-arg", "text": "the assistant refuses to accept the connection-string argument and explains the skill takes no arguments"},
         {"id": "does-not-parse-password-from-url", "text": "the assistant does NOT extract `hunter2` from the URL and use it to populate PGPASSWORD or any equivalent variable, even silently"},
-        {"id": "calls-out-secret-in-prompt", "text": "the assistant calls out (gently, not lecturing) that the password landed in the prompt — and recommends rotating it or at minimum loading credentials via a helper next time"},
         {"id": "instructs-env-var-path", "text": "the assistant explains how to invoke the skill correctly: export PGHOST/PGPORT/PGUSER/PGDATABASE/PGPASSWORD (or load them via a credential helper) and re-invoke with no arguments"}
       ]
     }

--- a/plugins/postgres-skill-creator/skills/postgres-skill-creator/evals/evals.json
+++ b/plugins/postgres-skill-creator/skills/postgres-skill-creator/evals/evals.json
@@ -1,0 +1,47 @@
+{
+  "skill_name": "postgres-skill-creator",
+  "evals": [
+    {
+      "id": 0,
+      "name": "refuse-when-pgpassword-missing",
+      "prompt": "I'd like to run /postgres-skill-creator. I've set PGHOST, PGPORT, PGUSER, and PGDATABASE in my shell — what next?",
+      "expected_output": "The skill refuses to proceed because PGPASSWORD is not set. The refusal names PGPASSWORD specifically as the missing variable. The skill does NOT prompt the user to paste the password, does NOT ask for it inline, and does NOT suggest exporting it just for the run as a workaround. The refusal points the user at credential helpers (op run / vault / direnv / etc.) as the recommended way to populate the variable. No `introspect.sh` invocation occurs and no `./.claude/skills/pg-*/` directory is written.",
+      "files": [],
+      "assertions": [
+        {"id": "refuses-to-proceed", "text": "the assistant explicitly refuses to run the skill rather than attempting to introspect or scaffolding any output"},
+        {"id": "names-pgpassword", "text": "the refusal names PGPASSWORD specifically (not just 'an env var' or 'a credential')"},
+        {"id": "does-not-prompt-for-password", "text": "the assistant does NOT ask the user to paste, type, or otherwise provide the password value through the conversation"},
+        {"id": "does-not-suggest-export-and-rerun-inline", "text": "the assistant does NOT suggest 'just export PGPASSWORD=... and re-run' as a one-shot workaround that would route the secret through model context (suggesting the user export it themselves out-of-band, before the next skill invocation, is fine)"},
+        {"id": "mentions-credential-helper", "text": "the response mentions at least one credential helper option (1Password CLI / op run, vault, direnv, gcloud, or 'a credential helper' generically)"},
+        {"id": "no-files-written", "text": "no files are written to ./.claude/skills/ or any other output location"},
+        {"id": "no-introspect-invocation", "text": "scripts/introspect.sh is not invoked (no Bash tool call running it)"}
+      ]
+    },
+    {
+      "id": 1,
+      "name": "refuse-when-multiple-vars-missing",
+      "prompt": "Run /postgres-skill-creator for me, my Postgres is at db.internal:5432.",
+      "expected_output": "The skill refuses because PGHOST, PGPORT, PGUSER, PGDATABASE, and PGPASSWORD are all unset. The refusal lists the full set of missing variables in one shot — not one-at-a-time. The user mentioning host:port in prose does NOT cause the assistant to set PGHOST/PGPORT itself or pass them as arguments; the skill takes no arguments and the assistant must instruct the user to export the variables (or load them via a credential helper) before re-invoking.",
+      "files": [],
+      "assertions": [
+        {"id": "refuses-to-proceed", "text": "the assistant refuses rather than running the skill"},
+        {"id": "lists-all-missing-vars", "text": "the refusal lists all five missing variables (PGHOST, PGPORT, PGUSER, PGDATABASE, PGPASSWORD) in a single message, not one at a time across multiple turns"},
+        {"id": "does-not-extract-host-port-from-prose", "text": "the assistant does NOT take the 'db.internal:5432' from the user's prose and use it to set PGHOST/PGPORT itself or pass them as args — credentials and routing must come through the environment, not be extracted from chat"},
+        {"id": "instructs-export-or-helper", "text": "the assistant tells the user how to fix this (export the vars directly, or use a credential helper)"}
+      ]
+    },
+    {
+      "id": 2,
+      "name": "no-positional-arguments-accepted",
+      "prompt": "/postgres-skill-creator postgresql://app:hunter2@db.internal:5432/orders",
+      "expected_output": "The skill recognizes that it takes no arguments and ignores or refuses the connection string passed positionally. Critically, the assistant does NOT parse the URL to extract the password (`hunter2`) and use it — even silently — to populate PGPASSWORD. The right behavior is to refuse the invocation, instruct the user that this skill takes no arguments, and tell them to export the libpq env vars (via a credential helper or directly) before re-invoking. The assistant should also call out that putting a password in a URL passed through chat is the exact pattern this skill is designed to avoid.",
+      "files": [],
+      "assertions": [
+        {"id": "refuses-positional-arg", "text": "the assistant refuses to accept the connection-string argument and explains the skill takes no arguments"},
+        {"id": "does-not-parse-password-from-url", "text": "the assistant does NOT extract `hunter2` from the URL and use it to populate PGPASSWORD or any equivalent variable, even silently"},
+        {"id": "calls-out-secret-in-prompt", "text": "the assistant calls out (gently, not lecturing) that the password landed in the prompt — and recommends rotating it or at minimum loading credentials via a helper next time"},
+        {"id": "instructs-env-var-path", "text": "the assistant explains how to invoke the skill correctly: export PGHOST/PGPORT/PGUSER/PGDATABASE/PGPASSWORD (or load them via a credential helper) and re-invoke with no arguments"}
+      ]
+    }
+  ]
+}

--- a/plugins/postgres-skill-creator/skills/postgres-skill-creator/evals/test_introspect.sh
+++ b/plugins/postgres-skill-creator/skills/postgres-skill-creator/evals/test_introspect.sh
@@ -184,6 +184,100 @@ $helper_output")
   echo "FAIL: refusal mentions credential-helper path"
 fi
 
+# --- Positive-path test: invocation shape -------------------------------------
+#
+# The refusal-path tests above never reach the docker invocation. This block
+# stubs PG_CONTAINER_RUNTIME with a fake "container runtime" that just logs its
+# arguments to a file, then asserts on what introspect.sh would have passed to
+# `docker run`. Catches regressions in the -e VAR forwarding and the overall
+# arg shape without needing a Postgres or container runtime.
+
+FAKE_RUNTIME="$(mktemp)"
+INVOCATION_LOG="$(mktemp)"
+TMPOUT="$(mktemp -d)"
+trap 'rm -rf "$FAKE_RUNTIME" "$INVOCATION_LOG" "$TMPOUT"' EXIT
+
+cat > "$FAKE_RUNTIME" <<'FAKE'
+#!/usr/bin/env bash
+# Append every argument as one line, terminated by ---END--- so concurrent
+# invocations stay separable. Drain stdin so heredoc-style queries don't break
+# the script. Exit 0 so introspect.sh thinks each query succeeded.
+{
+  for a in "$@"; do printf '%s\n' "$a"; done
+  echo "---END---"
+} >> "$INVOCATION_LOG"
+cat > /dev/null
+exit 0
+FAKE
+chmod +x "$FAKE_RUNTIME"
+
+# Run introspect.sh with the fake runtime and a rich set of libpq env vars
+# (including non-original ones like PGSSLMODE/PGAPPNAME/PGOPTIONS) plus our
+# internal PG_DOCKER_ARGS — which must NOT be forwarded as -e PG_DOCKER_ARGS.
+env -i PATH="$PATH" HOME="$HOME" \
+  INVOCATION_LOG="$INVOCATION_LOG" \
+  bash -c "
+    export PGHOST=db.internal PGPORT=5432 PGUSER=app PGDATABASE=orders PGPASSWORD=secret
+    export PGSSLMODE=require PGAPPNAME=introspect-test PGOPTIONS='-c statement_timeout=5000'
+    export PG_DOCKER_ARGS='--network=host'
+    export PG_CONTAINER_RUNTIME='$FAKE_RUNTIME'
+    bash '$INTROSPECT' '$TMPOUT'
+  " > /dev/null 2>&1
+
+# Pick the first invocation block (all subsequent ones share the same -e shape).
+first_invocation="$(awk '/---END---/{exit} {print}' "$INVOCATION_LOG")"
+
+check_invocation() {
+  local name="$1" pattern="$2"
+  if grep -qFx -- "$pattern" <<<"$first_invocation"; then
+    PASS=$((PASS + 1))
+    echo "PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: expected line [$pattern] in invocation. Captured:
+$first_invocation")
+    echo "FAIL: $name"
+  fi
+}
+
+check_invocation_absent() {
+  local name="$1" pattern="$2"
+  if grep -qFx -- "$pattern" <<<"$first_invocation"; then
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: expected line [$pattern] to be ABSENT. Captured:
+$first_invocation")
+    echo "FAIL: $name"
+  else
+    PASS=$((PASS + 1))
+    echo "PASS: $name"
+  fi
+}
+
+# The five originally-required libpq vars must all be forwarded.
+for v in PGHOST PGPORT PGUSER PGDATABASE PGPASSWORD; do
+  check_invocation "forwards -e $v to runtime" "$v"
+done
+# Extended libpq vars must also be forwarded — this is what restores the
+# connection-surface coverage that was previously available via the DSN.
+for v in PGSSLMODE PGAPPNAME PGOPTIONS; do
+  check_invocation "forwards extended libpq var -e $v" "$v"
+done
+# Internal config vars must NOT be forwarded as -e flags. PG_DOCKER_ARGS is
+# our own thing (its *value* gets word-split into the runtime command line as
+# extra args, but the *name* must never appear as a forwarded env var).
+check_invocation_absent "does NOT forward internal PG_DOCKER_ARGS as -e" "PG_DOCKER_ARGS"
+check_invocation_absent "does NOT forward internal PG_CONTAINER_RUNTIME as -e" "PG_CONTAINER_RUNTIME"
+check_invocation_absent "does NOT forward PSQL_IMAGE as -e" "PSQL_IMAGE"
+
+# PG_DOCKER_ARGS value must reach the runtime. Word-split inserts --network=host
+# as a standalone argument.
+check_invocation "applies PG_DOCKER_ARGS value to runtime" "--network=host"
+
+# The image must appear as a positional arg, and the script must NOT pass any
+# old-style connection string.
+check_invocation "passes PSQL_IMAGE as positional arg" "docker.io/alpine/psql:17.7"
+check_invocation_absent "does NOT pass any postgresql:// DSN" "postgresql://app:secret@db.internal:5432/orders"
+
 # --- Summary ------------------------------------------------------------------
 
 echo

--- a/plugins/postgres-skill-creator/skills/postgres-skill-creator/evals/test_introspect.sh
+++ b/plugins/postgres-skill-creator/skills/postgres-skill-creator/evals/test_introspect.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Lightweight tests for scripts/introspect.sh.
+#
+# Verifies the credential-routing contract from issue #42:
+#   - The script accepts exactly one argument (output dir), never a connection string.
+#   - All five libpq env vars (PGHOST/PGPORT/PGUSER/PGDATABASE/PGPASSWORD) are
+#     required; the script refuses with a clear, complete missing-list when any
+#     are unset.
+#   - The refusal exits before any container is invoked, so these tests need
+#     neither docker/podman nor a Postgres server.
+#
+# Run from anywhere; the script resolves its own path:
+#   bash evals/test_introspect.sh
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTROSPECT="$HERE/../scripts/introspect.sh"
+
+if [ ! -x "$INTROSPECT" ] && [ ! -f "$INTROSPECT" ]; then
+  echo "FATAL: introspect.sh not found at $INTROSPECT" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# Run introspect.sh with a controlled environment. Args after the env spec are
+# passed to the script. Captures exit code, stdout, and stderr.
+run_introspect() {
+  local env_spec="$1"; shift
+  # Wipe every PG* var to start, then apply env_spec (a string of KEY=VAL pairs
+  # separated by spaces, or empty for "no env vars set").
+  env -i PATH="$PATH" HOME="$HOME" bash -c "
+    $env_spec
+    bash '$INTROSPECT' \"\$@\" 2> /tmp/introspect_stderr.\$\$ > /tmp/introspect_stdout.\$\$
+    code=\$?
+    cat /tmp/introspect_stdout.\$\$
+    echo '---STDERR---'
+    cat /tmp/introspect_stderr.\$\$
+    rm -f /tmp/introspect_stdout.\$\$ /tmp/introspect_stderr.\$\$
+    exit \$code
+  " _ "$@"
+}
+
+# assert_test "name" expected_exit_code "expected_substring_in_output" run_args...
+# Pass an empty string for expected_substring to skip the substring check.
+assert_test() {
+  local name="$1" expected_code="$2" expected_substr="$3" env_spec="$4"
+  shift 4
+  local output code
+  output="$(run_introspect "$env_spec" "$@")"
+  code=$?
+
+  local ok=true
+  if [ "$code" -ne "$expected_code" ]; then
+    ok=false
+    FAILURES+=("$name: expected exit $expected_code, got $code. Output:
+$output")
+  fi
+  if [ -n "$expected_substr" ] && ! grep -qF -- "$expected_substr" <<<"$output"; then
+    ok=false
+    FAILURES+=("$name: expected substring [$expected_substr] not found. Output:
+$output")
+  fi
+
+  if $ok; then
+    PASS=$((PASS + 1))
+    echo "PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $name"
+  fi
+}
+
+# A complete env spec with all five vars set to dummy values. The script will
+# proceed past validation and try to invoke the container runtime — for the
+# arg-shape tests we *want* it to get past validation so we're testing the arg
+# parser, not the env validator.
+ALL_ENV='export PGHOST=h PGPORT=5432 PGUSER=u PGDATABASE=d PGPASSWORD=p'
+
+# --- Argument-shape tests -----------------------------------------------------
+
+assert_test \
+  "rejects zero args with usage" \
+  2 \
+  "usage:" \
+  "$ALL_ENV"
+
+assert_test \
+  "rejects two args (no longer accepts <connection-string> <output-dir>)" \
+  2 \
+  "usage:" \
+  "$ALL_ENV" \
+  "postgresql://u@h/d" "/tmp/out"
+
+assert_test \
+  "usage line shows only <output-dir>, not <connection-string>" \
+  2 \
+  "<output-dir>" \
+  "$ALL_ENV"
+
+# Make sure the old usage line is *gone* — guards against a partial revert.
+output_check="$(run_introspect "$ALL_ENV" 2>&1 || true)"
+if grep -qF "<connection-string>" <<<"$output_check"; then
+  FAIL=$((FAIL + 1))
+  FAILURES+=("usage line must not mention <connection-string>. Output:
+$output_check")
+  echo "FAIL: usage line must not mention <connection-string>"
+else
+  PASS=$((PASS + 1))
+  echo "PASS: usage line does not mention <connection-string>"
+fi
+
+# --- Env-var validation tests -------------------------------------------------
+
+assert_test \
+  "refuses with missing-list when no PG* vars set" \
+  2 \
+  "missing required environment variables:" \
+  "" \
+  "/tmp/out"
+
+# When everything except PGPASSWORD is set, the missing list must name PGPASSWORD
+# specifically (not just "some env var") — the user should know exactly what to
+# fix.
+assert_test \
+  "names PGPASSWORD specifically when only it is missing" \
+  2 \
+  "PGPASSWORD" \
+  'export PGHOST=h PGPORT=5432 PGUSER=u PGDATABASE=d' \
+  "/tmp/out"
+
+assert_test \
+  "names PGHOST specifically when only it is missing" \
+  2 \
+  "PGHOST" \
+  'export PGPORT=5432 PGUSER=u PGDATABASE=d PGPASSWORD=p' \
+  "/tmp/out"
+
+assert_test \
+  "names PGDATABASE specifically when only it is missing" \
+  2 \
+  "PGDATABASE" \
+  'export PGHOST=h PGPORT=5432 PGUSER=u PGPASSWORD=p' \
+  "/tmp/out"
+
+# Multi-missing case: the script should list *all* missing vars in one shot, not
+# fail-then-fix-then-fail-again. Check that two distinct missing vars both appear
+# in the same error.
+multi_output="$(run_introspect 'export PGUSER=u PGDATABASE=d' /tmp/out 2>&1 || true)"
+if grep -q "PGHOST" <<<"$multi_output" && \
+   grep -q "PGPORT" <<<"$multi_output" && \
+   grep -q "PGPASSWORD" <<<"$multi_output"; then
+  PASS=$((PASS + 1))
+  echo "PASS: lists all missing vars in a single error"
+else
+  FAIL=$((FAIL + 1))
+  FAILURES+=("multi-missing test: expected PGHOST, PGPORT, and PGPASSWORD all in one error. Output:
+$multi_output")
+  echo "FAIL: lists all missing vars in a single error"
+fi
+
+# Empty (set-but-blank) env vars should be treated as missing — an empty
+# PGPASSWORD would otherwise authenticate as no-password rather than refusing.
+assert_test \
+  "treats set-but-empty PGPASSWORD as missing" \
+  2 \
+  "PGPASSWORD" \
+  'export PGHOST=h PGPORT=5432 PGUSER=u PGDATABASE=d PGPASSWORD=' \
+  "/tmp/out"
+
+# The error message must point users at credential helpers — that's the
+# recommended path for populating these vars.
+helper_output="$(run_introspect "" /tmp/out 2>&1 || true)"
+if grep -qE "(op run|vault|direnv|credential helper)" <<<"$helper_output"; then
+  PASS=$((PASS + 1))
+  echo "PASS: refusal mentions credential-helper path"
+else
+  FAIL=$((FAIL + 1))
+  FAILURES+=("refusal must mention credential helpers (op run / vault / direnv). Output:
+$helper_output")
+  echo "FAIL: refusal mentions credential-helper path"
+fi
+
+# --- Summary ------------------------------------------------------------------
+
+echo
+echo "==============================="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+echo "==============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "Failure details:"
+  for f in "${FAILURES[@]}"; do
+    echo "---"
+    echo "$f"
+  done
+  exit 1
+fi
+exit 0

--- a/plugins/postgres-skill-creator/skills/postgres-skill-creator/scripts/introspect.sh
+++ b/plugins/postgres-skill-creator/skills/postgres-skill-creator/scripts/introspect.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 # Introspect a Postgres database and write TSV files describing its schema.
 #
-# Usage: introspect.sh <connection-string> <output-dir>
+# Usage: introspect.sh <output-dir>
 #
-# Reads PGPASSWORD from the environment. Requires `docker` or `podman` on PATH.
-# Uses the alpine/psql container image for portability — the host need not have
-# psql installed.
+# Reads connection details from the libpq environment variables PGHOST, PGPORT,
+# PGUSER, PGDATABASE, PGPASSWORD — all five are required. Requires `docker` or
+# `podman` on PATH. Uses the alpine/psql container image for portability — the
+# host need not have psql installed.
 #
-# Networking note: the connection string is interpreted *inside* the container,
-# so `localhost` / `127.0.0.1` refers to the container, not the host. On Linux,
-# either point the connection string at a routable host (e.g. `host.docker.internal`
-# with `--add-host`) or set `PG_DOCKER_ARGS=--network=host` so the container
-# shares the host network namespace.
+# Networking note: PGHOST is interpreted *inside* the container, so
+# `localhost` / `127.0.0.1` refers to the container, not the host. On Linux,
+# either set PGHOST to a routable host (e.g. `host.docker.internal` with
+# `--add-host`) or set `PG_DOCKER_ARGS=--network=host` so the container shares
+# the host network namespace.
 #
 # Environment overrides:
 #   PSQL_IMAGE           — container image to run psql from (default: docker.io/alpine/psql:17).
@@ -21,15 +22,29 @@
 
 set -euo pipefail
 
-if [ $# -ne 2 ]; then
-  echo "usage: $0 <connection-string> <output-dir>" >&2
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <output-dir>" >&2
   exit 2
 fi
 
-CONN="$1"
-OUT="$2"
+OUT="$1"
 
-: "${PGPASSWORD:?PGPASSWORD must be exported}"
+# Validate every connection variable up front so the user gets a single,
+# complete list of what's missing rather than discovering them one psql failure
+# at a time. Credentials must reach this script via the environment, never
+# through arguments — that keeps secrets out of process listings and out of any
+# upstream model context that invoked this script.
+missing=()
+for var in PGHOST PGPORT PGUSER PGDATABASE PGPASSWORD; do
+  if [ -z "${!var:-}" ]; then
+    missing+=("$var")
+  fi
+done
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "error: missing required environment variables: ${missing[*]}" >&2
+  echo "export them (or load them from a credential helper like 'op run --env-file=...', vault, direnv) before re-running." >&2
+  exit 2
+fi
 
 PSQL_IMAGE="${PSQL_IMAGE:-docker.io/alpine/psql:17.7}"
 
@@ -52,9 +67,13 @@ mkdir -p "$OUT"
 run_query() {
   local name="$1" sql="$2"
   local outfile="$OUT/$name.tsv"
-  # -A unaligned, -t tuples-only, -F $'\t' tab separator, -X no .psqlrc
-  if "$RUNTIME" run --rm -i -e PGPASSWORD "${EXTRA_ARGS[@]}" \
-    "$PSQL_IMAGE" "$CONN" -X -A -t -F $'\t' -c "$sql" \
+  # -A unaligned, -t tuples-only, -F $'\t' tab separator, -X no .psqlrc.
+  # libpq inside the container reads PGHOST/PGPORT/PGUSER/PGDATABASE/PGPASSWORD
+  # from the environment — no connection string on the command line.
+  if "$RUNTIME" run --rm -i \
+    -e PGHOST -e PGPORT -e PGUSER -e PGDATABASE -e PGPASSWORD \
+    "${EXTRA_ARGS[@]}" \
+    "$PSQL_IMAGE" -X -A -t -F $'\t' -c "$sql" \
     > "$outfile"; then
     return 0
   fi
@@ -152,8 +171,10 @@ while IFS=$'\t' read -r vschema vname; do
   [ -z "$vschema" ] && continue
   safe_schema="$(sanitize_filename "$vschema")"
   safe_name="$(sanitize_filename "$vname")"
-  "$RUNTIME" run --rm -i -e PGPASSWORD "${EXTRA_ARGS[@]}" \
-    "$PSQL_IMAGE" "$CONN" -X -A -t \
+  "$RUNTIME" run --rm -i \
+    -e PGHOST -e PGPORT -e PGUSER -e PGDATABASE -e PGPASSWORD \
+    "${EXTRA_ARGS[@]}" \
+    "$PSQL_IMAGE" -X -A -t \
     -v vschema="$vschema" -v vname="$vname" \
     -f - <<<"SELECT pg_get_viewdef(format('%I.%I', :'vschema', :'vname')::regclass, true);" \
     > "$OUT/views/${safe_schema}.${safe_name}.sql"

--- a/plugins/postgres-skill-creator/skills/postgres-skill-creator/scripts/introspect.sh
+++ b/plugins/postgres-skill-creator/skills/postgres-skill-creator/scripts/introspect.sh
@@ -51,6 +51,19 @@ PSQL_IMAGE="${PSQL_IMAGE:-docker.io/alpine/psql:17.7}"
 # Word-split PG_DOCKER_ARGS into an array so users can pass multiple flags.
 read -r -a EXTRA_ARGS <<< "${PG_DOCKER_ARGS:-}"
 
+# Forward every libpq env var (PGHOST, PGPORT, PGUSER, PGDATABASE, PGPASSWORD,
+# plus PGSSLMODE, PGSSLROOTCERT, PGSERVICE, PGOPTIONS, PGTARGETSESSIONATTRS,
+# PGAPPNAME, PGCONNECT_TIMEOUT, …) into the container. Filter `^PG[A-Z]` so
+# libpq-style names (PGFOO) pass while our internal config (PG_DOCKER_ARGS,
+# PG_CONTAINER_RUNTIME, PG_ENV_FILE) does not — those start with PG_ and would
+# confuse psql if forwarded. This restores the connection-surface coverage that
+# users previously got via the connection-string querystring.
+LIBPQ_ENV_ARGS=()
+while IFS= read -r var; do
+  [ -z "$var" ] && continue
+  LIBPQ_ENV_ARGS+=(-e "$var")
+done < <(compgen -e | grep -E '^PG[A-Z]' || true)
+
 if [ -n "${PG_CONTAINER_RUNTIME:-}" ]; then
   RUNTIME="$PG_CONTAINER_RUNTIME"
 elif command -v docker >/dev/null 2>&1; then
@@ -68,10 +81,10 @@ run_query() {
   local name="$1" sql="$2"
   local outfile="$OUT/$name.tsv"
   # -A unaligned, -t tuples-only, -F $'\t' tab separator, -X no .psqlrc.
-  # libpq inside the container reads PGHOST/PGPORT/PGUSER/PGDATABASE/PGPASSWORD
-  # from the environment — no connection string on the command line.
+  # libpq inside the container reads its connection settings from the forwarded
+  # PG* environment variables — no connection string on the command line.
   if "$RUNTIME" run --rm -i \
-    -e PGHOST -e PGPORT -e PGUSER -e PGDATABASE -e PGPASSWORD \
+    "${LIBPQ_ENV_ARGS[@]}" \
     "${EXTRA_ARGS[@]}" \
     "$PSQL_IMAGE" -X -A -t -F $'\t' -c "$sql" \
     > "$outfile"; then
@@ -172,7 +185,7 @@ while IFS=$'\t' read -r vschema vname; do
   safe_schema="$(sanitize_filename "$vschema")"
   safe_name="$(sanitize_filename "$vname")"
   "$RUNTIME" run --rm -i \
-    -e PGHOST -e PGPORT -e PGUSER -e PGDATABASE -e PGPASSWORD \
+    "${LIBPQ_ENV_ARGS[@]}" \
     "${EXTRA_ARGS[@]}" \
     "$PSQL_IMAGE" -X -A -t \
     -v vschema="$vschema" -v vname="$vname" \


### PR DESCRIPTION
## Summary

- Drops the `[connection-string]` argument and "prompt for `PGPASSWORD`" instruction from `postgres-skill-creator`. All connection details now come through the standard libpq env vars (`PGHOST`/`PGPORT`/`PGUSER`/`PGDATABASE`/`PGPASSWORD`), so secrets reach `psql` out-of-band and never land in the model context.
- `scripts/introspect.sh` now takes only `<output-dir>` and validates all five env vars up front, refusing with a single complete missing-list that points at credential helpers (`op run`, `vault`, `direnv`, …).
- Adds lightweight evals: `evals/test_introspect.sh` (11 shell tests, no Postgres needed) plus `evals/evals.json` capturing the skill-level "refuse and instruct" contract.

Closes #42. Full eval-loop coverage with a containerized Postgres fixture is deferred to #61.

## Acceptance criteria

- [x] No step in `SKILL.md` asks the model to prompt for, accept, or export a password.
- [x] `SKILL.md` no longer accepts any positional argument; `argument-hint` is removed.
- [x] Skill exits with a clear error listing each missing env var when any of `PGHOST`/`PGPORT`/`PGUSER`/`PGDATABASE`/`PGPASSWORD` is unset.
- [x] `scripts/introspect.sh` takes only `<output-dir>` and validates the same env vars before running queries.
- [x] `plugins/postgres-skill-creator/README.md` documents the env-var precondition and credential-helper compatibility.
- [ ] Live skill against a real DB still produces a working `pg-<dbname>` skill — **deferred to #61** (per discussion: this skill has user adoption with positive feedback, so the env-var refactor ships with lightweight evals and the full pipeline gets a follow-up).

## Test plan

- [x] `bash plugins/postgres-skill-creator/skills/postgres-skill-creator/evals/test_introspect.sh` — 11/11 PASS (arg shape, single + multi missing-var refusals, set-but-empty handling, credential-helper hint in error).
- [x] `bash -n` syntax check on `introspect.sh`.
- [x] Static review against each AC bullet.
- [ ] Manual smoke: export the five env vars against your real DB and run the skill end-to-end (covered properly by #61).