### PR TITLE
story(issue-60): drop inert pr-mode dismissal step

### DIFF
--- a/plugins/audit-skill/skills/audit-skill/SKILL.md
+++ b/plugins/audit-skill/skills/audit-skill/SKILL.md
@@ -14,7 +14,7 @@ This skill is itself bound by the same five objectives. If you find yourself wan
 This skill is idempotent in both modes; re-running on the same target is a documented refresh path.
 
 - **File mode** — overwrites `audit-<skill-name>-<YYYY-MM-DD>.md` on re-run. Two runs on different days produce two dated reports (intentional — the date is part of the path).
-- **PR mode** — deduplicates against prior audits via a marker line (`<!-- audit-skill: $HEAD_SHA -->`, where `$HEAD_SHA` is replaced with the actual commit SHA) on the summary review. If a marker matches the current head SHA, skip posting and tell the user the existing review URL; if a marker is for an older SHA, dismiss it before posting fresh. See `references/pr-mode.md` for the exact procedure.
+- **PR mode** — deduplicates against prior audits via a marker line (`<!-- audit-skill: $HEAD_SHA -->`, where `$HEAD_SHA` is replaced with the actual commit SHA) on the summary review. If a marker matches the current head SHA, skip posting and tell the user the existing review URL; if a marker is for an older SHA, post a fresh review (older-SHA reviews remain visible — the marker carries the dedup load, since GitHub's API forbids dismissing the `event=COMMENT` reviews this skill posts). See `references/pr-mode.md` for the exact procedure.
 
 ## Inputs
 

--- a/plugins/audit-skill/skills/audit-skill/evals/evals.json
+++ b/plugins/audit-skill/skills/audit-skill/evals/evals.json
@@ -128,5 +128,13 @@
         {"id": "findings-flat-by-objective", "text": "findings are grouped by objective, not by severity"}
       ]
     }
+  ],
+  "regression_checks": [
+    {
+      "id": "issue-60-pr-mode-dismissal-removed",
+      "script": "regression_pr_mode_dismissal.sh",
+      "text": "audit-skill must not invoke `gh api -X PUT .../reviews/<id>/dismissals` — GitHub rejects dismissals on event=COMMENT reviews (HTTP 422), and audit-skill posts with event=COMMENT. The marker line is the dedup mechanism. See issue #60.",
+      "kind": "static-source-check"
+    }
   ]
 }

--- a/plugins/audit-skill/skills/audit-skill/evals/regression_pr_mode_dismissal.sh
+++ b/plugins/audit-skill/skills/audit-skill/evals/regression_pr_mode_dismissal.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Regression check for issue #60: audit-skill must not instruct callers to
+# dismiss its own PR reviews. The skill posts with event=COMMENT (pr-mode.md
+# step 4), and GitHub's API rejects dismissals on COMMENT-event reviews with
+# HTTP 422 "Can not dismiss a commented pull request review". The marker
+# line is the dedup mechanism; this script makes sure no future edit
+# silently reintroduces the inert dismissal call.
+
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PR_MODE="$SKILL_DIR/references/pr-mode.md"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+
+fail=0
+
+if grep -nE '/reviews/[^[:space:]]*/dismissals' "$PR_MODE" >/dev/null; then
+  echo "FAIL: $PR_MODE references /reviews/.../dismissals" >&2
+  grep -nE '/reviews/[^[:space:]]*/dismissals' "$PR_MODE" >&2
+  fail=1
+fi
+
+if grep -nE 'gh api[^|]*-X[[:space:]]+PUT[^|]*dismissals' "$PR_MODE" >/dev/null; then
+  echo "FAIL: $PR_MODE invokes \`gh api -X PUT ... dismissals\`" >&2
+  fail=1
+fi
+
+if grep -nE 'dismiss it before posting fresh' "$SKILL_MD" >/dev/null; then
+  echo "FAIL: $SKILL_MD still narrates the removed dismissal step" >&2
+  grep -nE 'dismiss it before posting fresh' "$SKILL_MD" >&2
+  fail=1
+fi
+
+if [[ $fail -eq 0 ]]; then
+  echo "OK: pr-mode dismissal step is absent (issue #60 regression guard)"
+fi
+
+exit "$fail"

--- a/plugins/audit-skill/skills/audit-skill/references/pr-mode.md
+++ b/plugins/audit-skill/skills/audit-skill/references/pr-mode.md
@@ -17,14 +17,15 @@ This file specifies the exact `gh` invocations the skill uses when a PR is open.
 
 Re-running the audit on the same head SHA must be a no-op. Without this guard, every re-run posts a duplicate review.
 
+The marker line on each summary review (`<!-- audit-skill: $HEAD_SHA -->`, posted in step 4) is the dedup mechanism. It distinguishes runs by SHA, lets you spot a prior audit on the current head, and lets PR readers see which commit each review covered. Prior-SHA reviews remain visible by design — the audit history is the audit trail; on a long-lived branch you'll see one summary review per audit run, and that's expected.
+
 1. List existing reviews: `gh api repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews --paginate -q '.[] | {id, body, commit_id, html_url}'`.
 2. Filter to reviews whose body starts with `<!-- audit-skill: ` — those are prior audit-skill runs.
 3. Decide:
    - **Marker matches `HEAD_SHA`**: an audit was already posted for this exact commit. Skip the rest of PR mode entirely. Tell the user the existing review URL and stop.
-   - **Marker is for an older SHA**: dismiss it before posting fresh. `gh api -X PUT repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews/$ID/dismissals -f message="superseded by audit on $HEAD_SHA"`. Continue to step 2.
-   - **No marker found**: continue to step 2.
+   - **Marker is for an older SHA**, or **no marker found**: continue to step 2. The new review will carry the current SHA's marker and supersede any prior ones in meaning, even though they remain visible.
 
-Dismissed reviews stay in the PR's history (collapsed), so the user can still see what changed between audits — that's the point of dismissing rather than deleting.
+Why no dismissal step: the GitHub API only allows dismissing reviews submitted as `APPROVE` or `REQUEST_CHANGES`. Audit-skill posts with `event=COMMENT` (step 4), which the API refuses to dismiss (HTTP 422 "Can not dismiss a commented pull request review"). Switching the audit to `REQUEST_CHANGES` would gate the merge; switching to `APPROVE` would auto-approve a PR the audit may have just flagged. Neither is appropriate for a static linter, so the marker carries the dedup load alone.
 
 ## Step 2: build the modified-line index
 


### PR DESCRIPTION
Fixes #60.

## Summary

- `references/pr-mode.md` step 1 no longer instructs callers to `PUT .../reviews/<id>/dismissals` — that call always 422'd against the `event=COMMENT` reviews this skill posts. The marker line was already carrying the dedup load; the procedure now documents that explicitly and adds a "Why no dismissal step" note covering the `APPROVE` / `REQUEST_CHANGES` non-options.
- `SKILL.md:17` narration synced to match (no longer says older-SHA reviews are dismissed).
- New `evals/regression_pr_mode_dismissal.sh` static check, registered under a new `regression_checks` key in `evals/evals.json` so it stays discoverable as part of the eval suite. Verified it FAILs on a planted regression and PASSes on the clean tree.
- End-to-end pr-mode behavioral coverage (`gh` shim + capture log) deferred to #70 — this fix is doc-only and the static check is sufficient for the specific regression.

## Test plan

- [x] `evals/regression_pr_mode_dismissal.sh` passes on the new tree
- [x] Same script FAILs when a `gh api -X PUT ... /dismissals` line is planted into `references/pr-mode.md`
- [x] `evals/evals.json` parses as valid JSON after the new `regression_checks` block
- [ ] Re-audit a real PR after merge and confirm no 422 in the transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)