### PR TITLE
story(issue-82): align binary partition table with canonical SPEC.md headings

### DIFF
--- a/plugins/file-library/skills/implement-go-binary-file-library/SKILL.md
+++ b/plugins/file-library/skills/implement-go-binary-file-library/SKILL.md
@@ -46,11 +46,13 @@ wc -l <package>/SPEC.md                # last-line marker for the final section
 
 Build a `(section, line_start, line_end)` table from that output. Each section ends one line before the next `## ` heading; the final section ends at `wc -l`. Map sections to phases:
 
-| Phase   | Sections to slice                                                                                          |
-|---------|------------------------------------------------------------------------------------------------------------|
-| types   | Overview, Conventions, Field Definitions, Encoding Tables, Versioning                                      |
-| decoder | Overview, Conventions, Field Definitions, Encoding Tables, Conditional/Optional Fields, Checksums, Padding, Examples |
-| encoder | Overview, Conventions, Field Definitions, Encoding Tables, Checksums, Padding, Examples                    |
+| Phase   | Sections to slice                                                                                                                  |
+|---------|------------------------------------------------------------------------------------------------------------------------------------|
+| types   | Overview, Conventions, Field Definitions, Encoding Tables, Versioning                                                              |
+| decoder | Overview, Conventions, Field Definitions, Encoding Tables, Conditional and Optional Fields, Checksums and Integrity, Padding and Alignment, Examples |
+| encoder | Overview, Conventions, Field Definitions, Encoding Tables, Checksums and Integrity, Padding and Alignment, Examples                |
+
+Match section names against `grep -n '^## '` output by **prefix**, not exact equality — a binary spec that abbreviates `## Checksums and Integrity` to `## Checksums` should still match. The canonical names above are what `new-go-binary-file-library` scaffolds, but specs adapted from external standards may diverge.
 
 Always include `Conventions` for every phase — byte order is load-bearing for all three.
 

--- a/plugins/file-library/skills/implement-go-binary-file-library/evals/evals.json
+++ b/plugins/file-library/skills/implement-go-binary-file-library/evals/evals.json
@@ -25,7 +25,8 @@
         {"id": "no-full-spec-copy", "text": "no copy of SPEC.md content was written to a scratch file in the package (e.g. _spec_structures.md should not exist)"},
         {"id": "context-summary-spec-tightened", "text": "SKILL.md specifies, for both _context_types.md and _context_decoder.md, a strict signature-only format (no rationale, no examples), a hard 400-line cap, and a chunk-and-relaunch protocol when the cap would be exceeded (issue #46 acceptance)"},
         {"id": "phase-chunking-spec-tightened", "text": "SKILL.md specifies the issue #47 phase-chunking protocol: an up-front scope gate in `Before you start` (numeric threshold, partitioning into sub-units along section boundaries, plan announced to the user before any subagent launches) and a `## Phase chunking` section saying sub-calls run serially, append to the running _context_types.md / _context_decoder.md, and do not full-read the growing types.go / decoder.go / encoder.go source file (issue #47 acceptance)"},
-        {"id": "small-fixture-no-partition", "text": "partition_plan.md exists in the package and reports `no partitioning needed` for every phase (tlv is below the 600-line gate, so no phase should partition)"}
+        {"id": "small-fixture-no-partition", "text": "partition_plan.md exists in the package and reports `no partitioning needed` for every phase (tlv is below the 600-line gate, so no phase should partition)"},
+        {"id": "section-names-canonical", "text": "SKILL.md's partition table uses canonical SPEC.md headings (`Conditional and Optional Fields`, `Checksums and Integrity`, `Padding and Alignment`) and documents the prefix-match rule for adapted specs (issue #82 acceptance)"}
       ]
     },
     {
@@ -51,7 +52,8 @@
         {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content (e.g. _spec_structures.md) was written to the package"},
         {"id": "context-summary-spec-tightened", "text": "SKILL.md specifies, for both _context_types.md and _context_decoder.md, a strict signature-only format (no rationale, no examples), a hard 400-line cap, and a chunk-and-relaunch protocol when the cap would be exceeded (issue #46 acceptance)"},
         {"id": "phase-chunking-spec-tightened", "text": "SKILL.md specifies the issue #47 phase-chunking protocol: an up-front scope gate in `Before you start` (numeric threshold, partitioning into sub-units along section boundaries, plan announced to the user before any subagent launches) and a `## Phase chunking` section saying sub-calls run serially, append to the running _context_types.md / _context_decoder.md, and do not full-read the growing types.go / decoder.go / encoder.go source file (issue #47 acceptance)"},
-        {"id": "small-fixture-no-partition", "text": "partition_plan.md exists in the package and reports `no partitioning needed` for every phase (tlv is below the 600-line gate, so no phase should partition)"}
+        {"id": "small-fixture-no-partition", "text": "partition_plan.md exists in the package and reports `no partitioning needed` for every phase (tlv is below the 600-line gate, so no phase should partition)"},
+        {"id": "section-names-canonical", "text": "SKILL.md's partition table uses canonical SPEC.md headings (`Conditional and Optional Fields`, `Checksums and Integrity`, `Padding and Alignment`) and documents the prefix-match rule for adapted specs (issue #82 acceptance)"}
       ]
     },
     {
@@ -76,7 +78,8 @@
         {"id": "no-full-spec-copy", "text": "no scratch copy of SPEC.md content was written to the package"},
         {"id": "context-summary-spec-tightened", "text": "SKILL.md specifies, for both _context_types.md and _context_decoder.md, a strict signature-only format (no rationale, no examples), a hard 400-line cap, and a chunk-and-relaunch protocol when the cap would be exceeded (issue #46 acceptance)"},
         {"id": "phase-chunking-spec-tightened", "text": "SKILL.md specifies the issue #47 phase-chunking protocol: an up-front scope gate in `Before you start` (numeric threshold, partitioning into sub-units along section boundaries, plan announced to the user before any subagent launches) and a `## Phase chunking` section saying sub-calls run serially, append to the running _context_types.md / _context_decoder.md, and do not full-read the growing types.go / decoder.go / encoder.go source file (issue #47 acceptance)"},
-        {"id": "small-fixture-no-partition", "text": "partition_plan.md exists in the package and reports `no partitioning needed` for every phase (tlv is below the 600-line gate, so no phase should partition)"}
+        {"id": "small-fixture-no-partition", "text": "partition_plan.md exists in the package and reports `no partitioning needed` for every phase (tlv is below the 600-line gate, so no phase should partition)"},
+        {"id": "section-names-canonical", "text": "SKILL.md's partition table uses canonical SPEC.md headings (`Conditional and Optional Fields`, `Checksums and Integrity`, `Padding and Alignment`) and documents the prefix-match rule for adapted specs (issue #82 acceptance)"}
       ]
     },
     {
@@ -107,7 +110,8 @@
         {"id": "partition-plan-announces-sub-units", "text": "partition_plan.md reports that at least one phase was partitioned into 2+ sub-units (tlvx's decoder-phase slices total over 600 lines, so the gate must trip)"},
         {"id": "partition-plan-serial-order", "text": "partition_plan.md's per-sub-unit start/done log shows non-overlapping timestamps within each partitioned phase (sub-unit i's `done` precedes sub-unit i+1's `starting`) — proof that sub-calls ran serially, not in parallel"},
         {"id": "context-summary-spec-tightened", "text": "SKILL.md specifies, for both _context_types.md and _context_decoder.md, a strict signature-only format (no rationale, no examples), a hard 400-line cap, and a chunk-and-relaunch protocol when the cap would be exceeded (issue #46 acceptance)"},
-        {"id": "phase-chunking-spec-tightened", "text": "SKILL.md specifies the issue #47 phase-chunking protocol: an up-front scope gate in `Before you start` (numeric threshold, partitioning into sub-units along section boundaries, plan announced to the user before any subagent launches) and a `## Phase chunking` section saying sub-calls run serially, append to the running _context_types.md / _context_decoder.md, and do not full-read the growing types.go / decoder.go / encoder.go source file (issue #47 acceptance)"}
+        {"id": "phase-chunking-spec-tightened", "text": "SKILL.md specifies the issue #47 phase-chunking protocol: an up-front scope gate in `Before you start` (numeric threshold, partitioning into sub-units along section boundaries, plan announced to the user before any subagent launches) and a `## Phase chunking` section saying sub-calls run serially, append to the running _context_types.md / _context_decoder.md, and do not full-read the growing types.go / decoder.go / encoder.go source file (issue #47 acceptance)"},
+        {"id": "section-names-canonical", "text": "SKILL.md's partition table uses canonical SPEC.md headings (`Conditional and Optional Fields`, `Checksums and Integrity`, `Padding and Alignment`) and documents the prefix-match rule for adapted specs (issue #82 acceptance)"}
       ]
     }
   ]

--- a/plugins/file-library/skills/implement-go-binary-file-library/evals/grade.py
+++ b/plugins/file-library/skills/implement-go-binary-file-library/evals/grade.py
@@ -413,6 +413,66 @@ def assertion_phase_chunking_spec() -> tuple[bool, str]:
     return ok, "; ".join(findings)
 
 
+def assertion_section_names_canonical() -> tuple[bool, str]:
+    """Verify SKILL.md's partition table uses canonical SPEC.md headings.
+
+    Acceptance from issue #82: the partition table must reference
+    `Conditional and Optional Fields`, `Checksums and Integrity`, and
+    `Padding and Alignment` (the canonical headings scaffolded by
+    `new-go-binary-file-library`), not the abbreviated forms
+    (`Conditional/Optional Fields`, `Checksums`, `Padding`) that won't
+    match `grep -n '^## '` output. The section must also document the
+    prefix-match rule so specs adapted from external standards still
+    resolve.
+
+    Anchored to the `## Partition SPEC.md by line range...` section so
+    unrelated prose elsewhere in SKILL.md cannot give a false positive.
+    """
+    text = skill_md_text()
+    section = extract_section(text, "Partition SPEC.md by line range (do not read the whole file)")
+    findings = []
+
+    section_present = bool(section.strip())
+    findings.append(f"section_present={section_present}")
+    if not section_present:
+        return False, "; ".join(findings) + " (no `## Partition SPEC.md...` section)"
+
+    canonical = [
+        "Conditional and Optional Fields",
+        "Checksums and Integrity",
+        "Padding and Alignment",
+    ]
+    for name in canonical:
+        present = name in section
+        findings.append(f"{name!r}={present}")
+        if not present:
+            return False, "; ".join(findings)
+
+    # Reject the abbreviated forms that motivated this issue. Match each
+    # in a way that won't false-positive on the canonical names: the
+    # slash form is unambiguous; for the bare words, require a trailing
+    # comma (table-cell separator) or pipe — the canonical forms always
+    # have " and " continuing after the bare word.
+    abbreviated_patterns = [
+        ("Conditional/Optional Fields", "Conditional/Optional Fields"),
+        ("Checksums (bare)", re.compile(r"\bChecksums\s*[,|]")),
+        ("Padding (bare)", re.compile(r"\bPadding\s*[,|]")),
+    ]
+    for label, pat in abbreviated_patterns:
+        if isinstance(pat, str):
+            hit = pat in section
+        else:
+            hit = bool(pat.search(section))
+        if hit:
+            findings.append(f"abbreviated_present={label}")
+            return False, "; ".join(findings)
+
+    section_lower = section.lower()
+    has_prefix_rule = "prefix" in section_lower and "match" in section_lower
+    findings.append(f"prefix_match_documented={has_prefix_rule}")
+    return has_prefix_rule, "; ".join(findings)
+
+
 def assertion_eval0_header(asid: str, pkg: Path, run_dir: Path) -> tuple[bool, str]:
     common = assertion_partition_common(asid, pkg)
     if common is not None:
@@ -533,6 +593,9 @@ def assertion_eval0_header(asid: str, pkg: Path, run_dir: Path) -> tuple[bool, s
     if asid == "phase-chunking-spec-tightened":
         return assertion_phase_chunking_spec()
 
+    if asid == "section-names-canonical":
+        return assertion_section_names_canonical()
+
     return False, f"unknown assertion id: {asid}"
 
 
@@ -635,6 +698,9 @@ def assertion_eval1_record(asid: str, pkg: Path, run_dir: Path) -> tuple[bool, s
     if asid == "phase-chunking-spec-tightened":
         return assertion_phase_chunking_spec()
 
+    if asid == "section-names-canonical":
+        return assertion_section_names_canonical()
+
     return False, f"unknown assertion id: {asid}"
 
 
@@ -714,6 +780,9 @@ def assertion_eval2_trailer(asid: str, pkg: Path, run_dir: Path) -> tuple[bool, 
 
     if asid == "phase-chunking-spec-tightened":
         return assertion_phase_chunking_spec()
+
+    if asid == "section-names-canonical":
+        return assertion_section_names_canonical()
 
     return False, f"unknown assertion id: {asid}"
 
@@ -865,6 +934,9 @@ def assertion_eval3_tlvx_header_extended(asid: str, pkg: Path, run_dir: Path) ->
 
     if asid == "phase-chunking-spec-tightened":
         return assertion_phase_chunking_spec()
+
+    if asid == "section-names-canonical":
+        return assertion_section_names_canonical()
 
     return False, f"unknown assertion id: {asid}"
 

--- a/plugins/file-library/skills/implement-go-binary-file-library/evals/grade.py
+++ b/plugins/file-library/skills/implement-go-binary-file-library/evals/grade.py
@@ -425,8 +425,12 @@ def assertion_section_names_canonical() -> tuple[bool, str]:
     prefix-match rule so specs adapted from external standards still
     resolve.
 
-    Anchored to the `## Partition SPEC.md by line range...` section so
-    unrelated prose elsewhere in SKILL.md cannot give a false positive.
+    Pinned to the partition table rows themselves — the `| decoder |`
+    and `| encoder |` lines — not just to "the canonical name appears
+    somewhere in the section." Otherwise a regression that abbreviates
+    the table rows but keeps the prefix-match prose paragraph (which
+    legitimately references the canonical heading by example) would
+    slip through.
     """
     text = skill_md_text()
     section = extract_section(text, "Partition SPEC.md by line range (do not read the whole file)")
@@ -437,35 +441,48 @@ def assertion_section_names_canonical() -> tuple[bool, str]:
     if not section_present:
         return False, "; ".join(findings) + " (no `## Partition SPEC.md...` section)"
 
-    canonical = [
-        "Conditional and Optional Fields",
-        "Checksums and Integrity",
-        "Padding and Alignment",
-    ]
-    for name in canonical:
-        present = name in section
-        findings.append(f"{name!r}={present}")
-        if not present:
-            return False, "; ".join(findings)
+    # Pull the per-phase table rows specifically. Each row starts with
+    # `| <phase> |` and ends at end-of-line; what we care about is the
+    # second cell — the comma-separated section list.
+    rows = {}
+    for phase in ("decoder", "encoder"):
+        m = re.search(rf"^\|\s*{phase}\s*\|([^\n]*)\|", section, re.MULTILINE)
+        if m:
+            rows[phase] = m.group(1)
+    missing_rows = [p for p in ("decoder", "encoder") if p not in rows]
+    if missing_rows:
+        findings.append(f"missing_table_rows={missing_rows}")
+        return False, "; ".join(findings)
 
-    # Reject the abbreviated forms that motivated this issue. Match each
-    # in a way that won't false-positive on the canonical names: the
+    # Canonical names required per row. Encoder doesn't list
+    # `Conditional and Optional Fields` (it has no encode-time
+    # contract), so it's only required in the decoder row.
+    required = {
+        "decoder": ["Conditional and Optional Fields", "Checksums and Integrity", "Padding and Alignment"],
+        "encoder": ["Checksums and Integrity", "Padding and Alignment"],
+    }
+    for phase, names in required.items():
+        for name in names:
+            present = name in rows[phase]
+            findings.append(f"{phase}_row.{name!r}={present}")
+            if not present:
+                return False, "; ".join(findings)
+
+    # Reject abbreviated forms in the table rows specifically. The
     # slash form is unambiguous; for the bare words, require a trailing
-    # comma (table-cell separator) or pipe — the canonical forms always
-    # have " and " continuing after the bare word.
+    # comma (table-cell separator) or pipe — the canonical forms
+    # always have " and " continuing after the bare word.
     abbreviated_patterns = [
         ("Conditional/Optional Fields", "Conditional/Optional Fields"),
         ("Checksums (bare)", re.compile(r"\bChecksums\s*[,|]")),
         ("Padding (bare)", re.compile(r"\bPadding\s*[,|]")),
     ]
-    for label, pat in abbreviated_patterns:
-        if isinstance(pat, str):
-            hit = pat in section
-        else:
-            hit = bool(pat.search(section))
-        if hit:
-            findings.append(f"abbreviated_present={label}")
-            return False, "; ".join(findings)
+    for phase, row in rows.items():
+        for label, pat in abbreviated_patterns:
+            hit = (pat in row) if isinstance(pat, str) else bool(pat.search(row))
+            if hit:
+                findings.append(f"{phase}_row.abbreviated_present={label}")
+                return False, "; ".join(findings)
 
     section_lower = section.lower()
     has_prefix_rule = "prefix" in section_lower and "match" in section_lower


### PR DESCRIPTION
## Summary

- Switch `implement-go-binary-file-library/SKILL.md`'s partition table to canonical SPEC.md headings (`Conditional and Optional Fields`, `Checksums and Integrity`, `Padding and Alignment`) and add a prefix-match guidance note so adapted specs that abbreviate still resolve.
- Mirrors the fix that landed for `review-file-library` on PR #80 (commit 42a0328); same bug existed verbatim in the implementer skill.
- Add a static SKILL.md-text assertion (`section-names-canonical`) to `grade.py` and all four evals, same shape as the existing `context-summary-spec-tightened` / `phase-chunking-spec-tightened` guards, so a regression to abbreviated names fails the grader instead of silently mis-slicing.

Closes #82.

## Why this matters

A name-equality lookup against `grep -n '^## '` output for `Conditional/Optional Fields`, `Checksums`, or `Padding` doesn't match the canonical `## Conditional and Optional Fields` / `## Checksums and Integrity` / `## Padding and Alignment` headings the scaffold emits — so the decoder/encoder phase subagents could silently miss exactly the sections they need.

## Test plan

- [x] Positive: `assertion_section_names_canonical()` returns `True` against the post-change SKILL.md.
- [x] Negative: each guard fires when its rule is violated — reverting any one canonical name to the abbreviated form fails the assertion; removing the prefix-match note fails the assertion.
- [x] Existing static SKILL.md-text assertions (`context-summary-spec-tightened`, `phase-chunking-spec-tightened`) still pass — no disturbance.
- [x] `evals.json` parses cleanly; all four evals carry the new assertion entry.
- [x] Fixtures already use canonical names (`grep -n '^## ' evals/fixtures/{tlv,tlvx}/SPEC.md`), so existing eval runs remain valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)